### PR TITLE
🔒 Fix SQL Injection in checkModuleItem

### DIFF
--- a/classes/permissions.class.php
+++ b/classes/permissions.class.php
@@ -125,7 +125,7 @@ class dPacl extends gacl_api {
 		$q = new DBQuery;
 		$q->addQuery('allow');
 		$q->addTable('dotpermissions');
-		$q->addWhere("permission='$op' AND axo='$item' AND user_id='$userid' and section='$module'");
+		$q->addWhere("permission='$op' AND axo=" . $q->quote($item) . " AND user_id='$userid' and section='$module'");
 		$q->addOrder('priority ASC,acl_id DESC');
 		$q->setLimit(1);
 		$arr = $q->loadHash();
@@ -139,11 +139,11 @@ class dPacl extends gacl_api {
 	  $IsProjectModifier = false;
       // Id of tasks and project
       if ($module == 'projects') {                                                   
-        $project_id = $item;
+        $project_id = (int) $item;
       } elseif ($module == 'macroprojects') {
-		$macroproject_id = $item;
+		$macroproject_id = (int) $item;
 	  } elseif ($module == 'tasks' || $module == 'task_log') {                          
-          $task_id = $item;
+          $task_id = (int) $item;
           // Grab $projet_id
   		    $sql = ('SELECT task_project FROM '.$dbprefix.'tasks WHERE task_id =' . $task_id); 
     	    $project_id = db_loadResult($sql);


### PR DESCRIPTION
🎯 **What:** Fixed a SQL injection vulnerability in `classes/permissions.class.php`.
⚠️ **Risk:** The `$item` parameter was being directly concatenated into SQL queries without sanitization, allowing an attacker to inject arbitrary SQL commands. This could lead to unauthorized data access or modification.
🛡️ **Solution:**
1. Cast `$item` to integer `(int)` before using it in SQL queries where it represents an ID (tasks, projects, macroprojects).
2. Used `$q->quote()` to escape `$item` in the generic `checkModuleItem` permission check query.

---
*PR created automatically by Jules for task [6630761463056560286](https://jules.google.com/task/6630761463056560286) started by @davmont*