### PR TITLE
Verify user permissions on project deletion

### DIFF
--- a/modules/projects/projects.class.php
+++ b/modules/projects/projects.class.php
@@ -91,10 +91,12 @@ class CProject extends CDpObject {
 
 	// overload canDelete
 	function canDelete(&$msg, $oid=null,$joins = NULL) {
-		// TODO: check if user permissions are considered when deleting a project
 		global $AppUI;
 
-		return getPermission('projects', 'delete', $oid);
+		if (!getPermission('projects', 'delete', $oid)) {
+			$msg = $AppUI->_('noDeletePermission');
+			return false;
+		}
 
 		// NOTE: I uncommented the dependencies check since it is
 		// very anoying having to delete all tasks before being able
@@ -106,9 +108,19 @@ class CProject extends CDpObject {
 		// call the parent class method to assign the oid
 		return CDpObject::canDelete($msg, $oid, $tables);
 		*/
+		return true;
 	}
 
 	function delete($oid = NULL, $history_desc = '', $history_proj = 0) {
+		if ($oid) {
+			$this->project_id = $oid;
+		}
+
+		$msg = '';
+		if (!$this->canDelete($msg, $this->project_id)) {
+			return $msg;
+		}
+
 		$this->load($this->project_id);
 		addHistory('projects', $this->project_id, 'delete', $this->project_name,
 		           $this->project_id);


### PR DESCRIPTION
Implemented user permission verification in `CProject::delete()` within `modules/projects/projects.class.php`.

Previously, `CProject::delete()` overrode `CDpObject::delete()` but failed to call `canDelete()` or check permissions, allowing unauthorized deletions if the method was called directly (bypassing controller checks).

Changes:
1.  Modified `CProject::delete()` to:
    *   Accept `$oid` parameter (consistent with `CDpObject::delete`).
    *   Call `$this->canDelete($msg, $this->project_id)` to verify permissions.
    *   Return the error message if permission is denied.
2.  Modified `CProject::canDelete()` to:
    *   Check `getPermission('projects', 'delete', $oid)`.
    *   Set `$msg = $AppUI->_('noDeletePermission')` and return `false` if permission is denied.
    *   Return `true` if permission is granted (previously it fell through returning `null`).

Verified with a standalone PHP script `test_project_delete_permissions.php` mocking the environment.

---
*PR created automatically by Jules for task [16572114983792069705](https://jules.google.com/task/16572114983792069705) started by @davmont*