### PR TITLE
🔒 Fix SQL Injection in Task Assignment

### DIFF
--- a/modules/tasks/do_task_assign_aed.php
+++ b/modules/tasks/do_task_assign_aed.php
@@ -11,7 +11,7 @@ $store = (int)dPgetParam($_POST, 'store', 0);
 $chUTP = (int)dPgetParam($_POST, 'chUTP', 0);
 $percentage_assignment = dPgetCleanParam($_POST, 'percentage_assignment');
 $user_task_priority = dPgetCleanParam($_POST, 'user_task_priority');
-$user_id = @$_POST['user_id'];
+$user_id = (int) @$_POST['user_id'];
 
 // prepare the percentage of assignment per user as required by CTask::updateAssigned()
 $hperc_assign_ar = array();

--- a/modules/tasks/tasks.class.php
+++ b/modules/tasks/tasks.class.php
@@ -1686,7 +1686,7 @@ class CTask extends CDpObject
 		$q = new DBQuery;
 		// delete all current entries
 		$q->setDelete('user_tasks');
-		$q->addWhere('task_id = ' . $this->task_id . ' AND user_id = ' . $user_id);
+		$q->addWhere('task_id = ' . $this->task_id . ' AND user_id = ' . (int)$user_id);
 		$q->exec();
 		$q->clear();
 	}


### PR DESCRIPTION
**What:**
Fixed a SQL Injection vulnerability in the task assignment functionality.

**Risk:**
An attacker could inject malicious SQL commands via the `user_id` POST parameter in the task assignment page (`do_task_assign_aed.php`). This could potentially lead to data loss (unauthorized deletion of user task assignments) or other SQL injection impacts. Specifically, injecting `1 OR 1=1` could delete all assignments.

**Solution:**
*   In `modules/tasks/do_task_assign_aed.php`, the `$user_id` variable is now explicitly cast to an integer using `(int)` before being used.
*   In `modules/tasks/tasks.class.php`, the `removeAssigned` method now also casts the `$user_id` argument to an integer before constructing the SQL query.
*   This ensures that any non-numeric input is converted to an integer, neutralizing SQL injection payloads.

---
*PR created automatically by Jules for task [17934062533831963246](https://jules.google.com/task/17934062533831963246) started by @davmont*