### PR TITLE
Fix SQL Injection in Authenticator Class

### DIFF
--- a/classes/authenticator.class.php
+++ b/classes/authenticator.class.php
@@ -91,7 +91,7 @@ if (!defined('DP_BASE_DIR')) {
 			$q  = new DBQuery;
 			$q->addTable('users');
 			$q->addQuery('user_id, user_password, user_contact');
-			$q->addWhere("user_username = '$username'");
+			$q->addWhere("user_username = " . $q->quote($username));
 			if (! $rs = $q->exec()) {
 				die($AppUI->_('Failed to get user details') . ' - error was ' . $db->ErrorMsg());
 			}
@@ -172,7 +172,7 @@ if (!defined('DP_BASE_DIR')) {
 			$q  = new DBQuery;
 			$q->addTable('users');
 			$q->addQuery('user_id, user_password');
-			$q->addWhere("user_username = '$username'");
+			$q->addWhere("user_username = " . $q->quote($username));
 			if (!$rs = $q->exec()) {
 				$q->clear();
 				return false;
@@ -188,7 +188,7 @@ if (!defined('DP_BASE_DIR')) {
 			return false;
 		}
 
-		function userId()
+		function userId($username = NULL)
 		{
 			return $this->user_id;
 		}
@@ -296,7 +296,7 @@ if (!defined('DP_BASE_DIR')) {
 			$q  = new DBQuery;
 			$result = false;
 			$q->addTable('users');
-			$q->addWhere("user_username = '$username'");
+			$q->addWhere("user_username = " . $q->quote($username));
 			$rs = $q->exec();
 			if ($rs->RecordCount() > 0) 
 			  $result = true;
@@ -304,16 +304,19 @@ if (!defined('DP_BASE_DIR')) {
 			return $result;
 		}
 
-		function userId($username)
+		function userId($username = NULL)
 		{
 			GLOBAL $db;
-			$q  = new DBQuery;
-			$q->addTable('users');
-			$q->addWhere("user_username = '$username'");
-			$rs = $q->exec();
-			$row = $rs->FetchRow();
-			$q->clear();
-			return $row["user_id"];	
+			if ($username) {
+				$q  = new DBQuery;
+				$q->addTable('users');
+				$q->addWhere("user_username = " . $q->quote($username));
+				$rs = $q->exec();
+				$row = $rs->FetchRow();
+				$q->clear();
+				return $row["user_id"];
+			}
+			return $this->user_id;
 		}
 
 		function createsqluser($username, $password, $ldap_attribs = Array())

--- a/classes/ui.class.php
+++ b/classes/ui.class.php
@@ -695,7 +695,7 @@ class CAppUI {
 		}
 		$auth =& getauth($auth_method);
 		
-		$username = trim(db_escape($username));
+		$username = trim($username);
 		$password = trim($password);
 
 		if (!$auth->authenticate($username, $password)) {
@@ -723,7 +723,7 @@ class CAppUI {
 		             . 'contact_department as user_department, contact_email as user_email, ' 
 		             . 'user_type');
 		$q->addJoin('contacts', 'con', 'contact_id = user_contact');
-		$q->addWhere("user_id = $user_id AND user_username = '$username'");
+		$q->addWhere("user_id = $user_id AND user_username = " . $q->quote($username));
 		$sql = $q->prepare();
 		$q->clear();
 		dprint(__FILE__, __LINE__, 7, ('Login SQL: ' . $sql));


### PR DESCRIPTION
This PR fixes a critical SQL injection vulnerability in the authentication flow. 
Previously, `$username` was interpolated directly into SQL queries in `authenticator.class.php`. While `CAppUI::login` attempted to escape it, other paths (like PostNuke auth) or direct usage were vulnerable. 
The fix moves the responsibility of SQL safety to the `Authenticator` classes by using `$q->quote()` (ADODB qstr) and removes the pre-escaping in `CAppUI::login` to prevent double-escaping issues. 
It also fixes a PHP strict standards fatal error regarding method signature compatibility for `userId`.

---
*PR created automatically by Jules for task [15327784856890352342](https://jules.google.com/task/15327784856890352342) started by @davmont*