### PR TITLE
Fix Reflected XSS in install/db.php

### DIFF
--- a/install/db.php
+++ b/install/db.php
@@ -32,7 +32,7 @@ if ($_POST['mode'] == 'upgrade') {
 }
 ?>
 <form name="instFrm" action="do_install_db.php" method="post">
-<input type="hidden" name="mode" value="<?php echo $_POST['mode']; ?>" />
+<input type="hidden" name="mode" value="<?php echo htmlspecialchars($_POST['mode'], ENT_QUOTES); ?>" />
 <table cellspacing="0" cellpadding="3" border="0" class="tbl" width="100%" align="center">
 	<tr>
 		<td class="title" colspan="2">Database Settings</td>
@@ -70,23 +70,23 @@ endif;
 	</tr>
 	<tr>
 		<td class="item">Database Host Name</td>
-		<td align="left"><input class="button" type="text" name="dbhost" value="<?php echo $dPconfig['dbhost']; ?>" title="The Name of the Host the Database Server is installed on" /></td>
+		<td align="left"><input class="button" type="text" name="dbhost" value="<?php echo htmlspecialchars($dPconfig['dbhost'], ENT_QUOTES); ?>" title="The Name of the Host the Database Server is installed on" /></td>
 	</tr>
 	<tr>
 		<td class="item">Database Name</td>
-		<td align="left"><input class="button" type="text" name="dbname" value="<?php echo  $dPconfig['dbname']; ?>" title="The Name of the Database dotProject will use and/or install" /></td>
+		<td align="left"><input class="button" type="text" name="dbname" value="<?php echo htmlspecialchars($dPconfig['dbname'], ENT_QUOTES); ?>" title="The Name of the Database dotProject will use and/or install" /></td>
 	</tr>
 	<tr>
 		<td class="item">Database Prefix</td>
-		<td align="left"><input class="button" type="text" name="dbprefix" value="<?php echo  $dPconfig['dbprefix']; ?>" title="The Prefix for the tables dotProject will use and/or install" /></td>
+		<td align="left"><input class="button" type="text" name="dbprefix" value="<?php echo htmlspecialchars($dPconfig['dbprefix'], ENT_QUOTES); ?>" title="The Prefix for the tables dotProject will use and/or install" /></td>
 	</tr>
 	<tr>
 		<td class="item">Database User Name</td>
-		<td align="left"><input class="button" type="text" name="dbuser" value="<?php echo $dPconfig['dbuser']; ?>" title="The Database User that dotProject uses for Database Connection" /></td>
+		<td align="left"><input class="button" type="text" name="dbuser" value="<?php echo htmlspecialchars($dPconfig['dbuser'], ENT_QUOTES); ?>" title="The Database User that dotProject uses for Database Connection" /></td>
 	</tr>
 	<tr>
 		<td class="item">Database User Password</td>
-		<td align="left"><input class="button" type="password" name="dbpass" value="<?php echo $dPconfig['dbpass']; ?>" title="The Password according to the above User." /></td>
+		<td align="left"><input class="button" type="password" name="dbpass" value="<?php echo htmlspecialchars($dPconfig['dbpass'], ENT_QUOTES); ?>" title="The Password according to the above User." /></td>
 	</tr>
 	<tr>
 		<td class="item">Use Persistent Connection?</td>
@@ -115,9 +115,9 @@ endif;
 		<td align="left"><input class="button" type="submit" name="dobackup" value="Download XML" title="Click here to retrieve a XML file containing your data that can be stored on your local system." /></td>
 	</tr>
 	<tr>
-		<td align="left"><br /><input class="button" type="submit" name="do_db" value="<?php echo $_POST['mode']; ?> db only" title="Try to set up the database with the given information." />
+		<td align="left"><br /><input class="button" type="submit" name="do_db" value="<?php echo htmlspecialchars($_POST['mode'], ENT_QUOTES); ?> db only" title="Try to set up the database with the given information." />
 		&nbsp;<input class="button" type="submit" name="do_cfg" value="write config file only" title="Write a config file with the details only." /></td>
-		<td align="right" class="item"><br />(Recommended) &nbsp;<input class="button" type="submit" name="do_db_cfg" value="<?php echo $_POST['mode']; ?> db & write cfg" title="Write config file and setup the database with the given information." /></td>
+		<td align="right" class="item"><br />(Recommended) &nbsp;<input class="button" type="submit" name="do_db_cfg" value="<?php echo htmlspecialchars($_POST['mode'], ENT_QUOTES); ?> db & write cfg" title="Write config file and setup the database with the given information." /></td>
 	</tr>
 </table>
 </form>


### PR DESCRIPTION
Fixed a Reflected Cross-Site Scripting (XSS) vulnerability in `install/db.php` where `$_POST['mode']` was echoed directly into HTML attributes without sanitization.

### Vulnerability
The `mode` parameter from the POST request was reflected back to the user in the `value` attribute of hidden input fields and submit buttons. This allowed an attacker to inject arbitrary HTML and JavaScript if they could trick a user into submitting a form with a malicious `mode` value (e.g., via a CSRF attack or social engineering).

### Fix
*   Applied `htmlspecialchars($_POST['mode'], ENT_QUOTES)` to all occurrences where `$_POST['mode']` is echoed into HTML attributes.
*   Also applied `htmlspecialchars($dPconfig[...], ENT_QUOTES)` to database configuration values (`dbhost`, `dbname`, `dbprefix`, `dbuser`, `dbpass`) echoed into input fields as a defense-in-depth measure.

### Verification
*   Created a reproduction script `reproduce_xss.php` which confirmed the vulnerability by detecting the raw payload in the output.
*   Verified the fix using the same script, ensuring the payload is now correctly escaped as HTML entities.
*   Performed a regression test `install/test_regression.php` to ensure that legitimate values are still populated correctly in the form fields.


---
*PR created automatically by Jules for task [17837371693974648283](https://jules.google.com/task/17837371693974648283) started by @davmont*