### PR TITLE
Fix deprecated optional parameter in db_connect

### DIFF
--- a/includes/db_adodb.php
+++ b/includes/db_adodb.php
@@ -18,7 +18,7 @@ require_once(DP_BASE_DIR.'/lib/adodb/adodb.inc.php');
 $db = NewADOConnection(dPgetConfig('dbtype'));
 $GLOBALS['ADODB_OUTP'] = 'db_dprint';
 
-function db_connect($host='localhost', $dbname, $user='root', $passwd='', $persist=false) {
+function db_connect($host, $dbname, $user='root', $passwd='', $persist=false) {
 	global $db, $ADODB_FETCH_MODE;
 
 	$ret_val = (($persist) ? $db->PConnect($host, $user, $passwd, $dbname)


### PR DESCRIPTION
Fixes a PHP 8 deprecation warning in `includes/db_adodb.php` where an optional parameter was declared before a required one. The user also reported a similar issue in `includes/functions.php`, but that file could not be found in the repository.

---
*PR created automatically by Jules for task [2871195340686255170](https://jules.google.com/task/2871195340686255170) started by @davmont*