### PR TITLE
PHP 8 Compatibility Updates for Core Classes

### DIFF
--- a/classes/libmail.class.php
+++ b/classes/libmail.class.php
@@ -202,7 +202,7 @@ function Receipt() {
  */
 function To($to, $reset=FALSE) {
 	if (is_array($to)) {
-		$to = array_map(create_function('$s', 'return strtr($s, "\x0B\0\t\r\n\f", "      ");'), $to);
+		$to = array_map(function($s) { return strtr($s, "\x0B\0\t\r\n\f", "      "); }, $to);
 		$this->ato = $to;
 	} else {
 		$to = strtr($to, "\x0B\0\t\r\n\f", '      ');
@@ -230,7 +230,7 @@ function To($to, $reset=FALSE) {
  */
 function Cc($cc) {
 	if (is_array($cc)) {
-		$cc = array_map(create_function('$s', 'return strtr($s, "\x0B\0\t\r\n\f", "      ");'), $cc);
+		$cc = array_map(function($s) { return strtr($s, "\x0B\0\t\r\n\f", "      "); }, $cc);
 		$this->acc = $cc;
 	} else {
 		$cc = strtr($cc, "\x0B\0\t\r\n\f", '      ');
@@ -248,7 +248,7 @@ function Cc($cc) {
  */
 function Bcc($bcc) {
 	if (is_array($bcc)) {
-		$bcc = array_map(create_function('$s', 'return strtr($s, "\x0B\0\t\r\n\f", "      ");'), $bcc);
+		$bcc = array_map(function($s) { return strtr($s, "\x0B\0\t\r\n\f", "      "); }, $bcc);
 		$this->abcc = $bcc;
 	} else {
 		$bcc = strtr($bcc, "\x0B\0\t\r\n\f", '      ');

--- a/classes/permissions.class.php
+++ b/classes/permissions.class.php
@@ -67,7 +67,7 @@ class dPacl extends gacl_api {
 		if (dPgetConfig('debug', 0) > 10) {
 			$this->_debug = true;
 		}
-		parent::gacl_api($opts);
+		parent::__construct($opts);
 	}
 	
 	function checkLogin($login) {

--- a/classes/query.class.php
+++ b/classes/query.class.php
@@ -888,7 +888,7 @@ class DBQuery {
 
 	function quote($string) {
 		global $db;
-		return $db->qstr($string, get_magic_quotes_runtime());
+		return $db->qstr($string);
 	}
 
 	/**

--- a/classes/tree.class.php
+++ b/classes/tree.class.php
@@ -90,8 +90,7 @@ class CDpTreeNode
 		if ($this->id == $id) {
 			return $this;
 		} else {
-			reset ($this->children);
-			while (list($newid, $node) = each($this->children)) {
+			foreach ($this->children as $newid => $node) {
 				if ($result =& $node->find($id)) {
 					return $result;
 				}
@@ -101,8 +100,7 @@ class CDpTreeNode
 	}
 
 	function display($method) {
-		reset($this->children);
-		while (list($id, $node) = each($this->children)) {
+		foreach ($this->children as $id => $node) {
 			call_user_func($method, $node->depth, $node->data);
 			$node->display($method);
 		}

--- a/classes/ui.class.php
+++ b/classes/ui.class.php
@@ -926,7 +926,7 @@ class CAppUI {
 			}
 		}
 		asort($js_files);
-		while (list(,$js_file_name) = each($js_files)) {
+		foreach ($js_files as $js_file_name) {
 			echo ('<script type="text/javascript" src="' . $base . 'js/' 
 				  . $this->___($js_file_name) . '"></script>'."\n");
 		}
@@ -990,7 +990,7 @@ class CTabBox_core {
 	 * @param string Optional javascript method to be used to execute tabs.
 	 *	Must support 2 arguments, currently active tab, new tab to activate.
 	 */
-	function CTabBox_core($baseHRef='', $baseInc='', $active=0, $javascript = null) {
+	function __construct($baseHRef='', $baseInc='', $active=0, $javascript = null) {
 		$baseHRef = str_replace('&amp;', '&', $baseHRef);
 		$baseHRef = htmlspecialchars($baseHRef);
 		
@@ -1197,7 +1197,7 @@ class CTitleBlock_core {
 	 * have permission to view the help module, then the context help icon is
 	 * not displayed.
 	 */
-	function CTitleBlock_core($title, $icon='', $module='', $helpref='') {
+	function __construct($title, $icon='', $module='', $helpref='') {
 		$this->title = $title;
 		$this->icon = $icon;
 		$this->module = $module;

--- a/lib/phpgacl/gacl.class.php
+++ b/lib/phpgacl/gacl.class.php
@@ -95,7 +95,7 @@ class gacl {
 	 * Constructor
 	 * @param array An arry of options to oeverride the class defaults
 	 */
-	function gacl($options = NULL) {
+	function __construct($options = NULL) {
 
 		$available_options = array('db','debug','items_per_page','max_select_box_items','max_search_return_items','db_table_prefix','db_type','db_host','db_user','db_password','db_name','caching','force_cache_expire','cache_dir','cache_expire_time');
 		if (is_array($options)) {


### PR DESCRIPTION
This change set addresses several PHP 8 compatibility issues:
1.  Renamed legacy PHP 4 constructors to `__construct` in `classes/ui.class.php` (for `CTabBox_core` and `CTitleBlock_core`) and `lib/phpgacl/gacl.class.php` (for `gacl`).
2.  Updated `classes/permissions.class.php` to call `parent::__construct()` instead of the now non-existent `parent::gacl_api()`.
3.  Removed the call to `get_magic_quotes_runtime()` in `classes/query.class.php` as it was removed in PHP 8.
4.  Replaced `create_function()` with closures in `classes/libmail.class.php`.
5.  Replaced `each()` loops with `foreach` in `classes/ui.class.php` and `classes/tree.class.php`.

Note: `CDpObject` in `classes/dp.class.php` retains its legacy constructor method alongside `__construct` to maintain backward compatibility with existing modules that explicitly call `$this->CDpObject()`.


---
*PR created automatically by Jules for task [8463896059181488514](https://jules.google.com/task/8463896059181488514) started by @davmont*