### PR TITLE
🧹 Remove dead code in db_free_result

### DIFF
--- a/includes/db_adodb.php
+++ b/includes/db_adodb.php
@@ -79,9 +79,6 @@ function db_exec($sql) {
 }
 
 function db_free_result($cur) {
-	// TODO
-	// mysql_free_result($cur);
-	// Maybe it's done my Adodb
 	if (!(is_object($cur))) {
 		dprint(__FILE__, __LINE__, 0, 'Invalid object passed to db_free_result.');
 	}


### PR DESCRIPTION
Removed dead code and comments in `includes/db_adodb.php`.
Verified with a reproduction script that mocks the ADOdb result object and confirms `Close()` is called.
Syntax check passed.

---
*PR created automatically by Jules for task [8472612116107635698](https://jules.google.com/task/8472612116107635698) started by @davmont*