### PR TITLE
Verify user permissions on closure deletion

### DIFF
--- a/modules/closure/closure.class.php
+++ b/modules/closure/closure.class.php
@@ -75,16 +75,25 @@ class CClosure extends CDpObject {
 		return $perms->checkModuleItem('closure', 'delete', $oid);
 	}
 
-	function delete() {
-		$this->load($this->project_id);
-		$details['name'] = $this->project_name;
-		addHistory('post_mortem_analysis', $this->project_name, 'delete', $details);
+	function delete($oid = NULL) {
+		$k = $this->_tbl_key;
+		if ($oid) {
+			$this->$k = intval($oid);
+		}
+		$oid = $this->$k;
 
-    $q = new DBQuery;
+		if (!$this->canDelete($msg, $oid)) {
+			return $msg;
+		}
+
+		$this->load($oid);
+		addHistory('post_mortem_analysis', $this->pma_id, 'delete', $this->project_name);
+
+		$q = new DBQuery;
 		$q->setDelete('post_mortem_analysis');
 		$q->addWhere('pma_id ='.$this->pma_id);
 
-    $result = ((!$q->exec())?db_error():NULL);
+		$result = ((!$q->exec())?db_error():NULL);
 		$q->clear();
 		return $result;
 	}

--- a/modules/closure/do_closure_aed.php
+++ b/modules/closure/do_closure_aed.php
@@ -17,13 +17,13 @@ $del = dPgetParam( $_POST, 'del', 0 );
 
 // prepare (and translate) the module name ready for the suffix
 if ($del) {
-	$project_id = dPgetParam($_POST, 'pma_id', 0);
+	$pma_id = dPgetParam($_POST, 'pma_id', 0);
 	$canDelete = $obj->canDelete($msg, $pma_id);
 	if (!$canDelete) {
 		$AppUI->setMsg( $msg, UI_MSG_ERROR );
 		$AppUI->redirect();
 	}
-	if (($msg = $obj->delete())) {
+	if (($msg = $obj->delete($pma_id))) {
 		$AppUI->setMsg( $msg, UI_MSG_ERROR );
 		$AppUI->redirect();
 	} else {


### PR DESCRIPTION
Implemented proper permission checks in `CClosure::delete` to prevent unauthorized deletion of closure items. The original implementation completely bypassed `canDelete`.
Also fixed a critical bug in `do_closure_aed.php` where an undefined variable `$project_id` was passed to `canDelete`, likely causing the check to fail or behave unexpectedly.
Refactored `delete` to correctly load the object by `pma_id` (fixing usage of undefined `$this->project_id`) and log history with valid arguments.

---
*PR created automatically by Jules for task [2838511886729875507](https://jules.google.com/task/2838511886729875507) started by @davmont*