### PR TITLE
Allow public access in Bugspray view

### DIFF
--- a/modules/bugspray/addedit.php
+++ b/modules/bugspray/addedit.php
@@ -299,7 +299,11 @@ function selectList( listName, target ) {
           }
         ?>
         />
-        <label for="in"><?=$AppUI->_( 'Notify by e-mail' );?></label></td>
+        <label for="in"><?=$AppUI->_( 'Notify by e-mail' );?></label>
+        &nbsp;&nbsp;
+        <input type="checkbox" name="item_public" value="1" id="ip"
+        <?php echo @$hditem['item_public'] ? 'checked' : ''; ?> />
+        <label for="ip"><?=$AppUI->_( 'Public' );?></label></td>
     </tr>
 
     <tr>

--- a/modules/bugspray/helpdesk.class.php
+++ b/modules/bugspray/helpdesk.class.php
@@ -50,6 +50,7 @@ class CHelpDeskItem extends CDpObject {
 
   var $item_assigned_to = NULL;
   var $item_notify = 0;
+  var $item_public = 0;
   var $item_requestor = NULL;
   var $item_requestor_id = NULL;
   var $item_requestor_email = NULL;
@@ -428,6 +429,6 @@ function getPermsWhereClause($mod, $mod_id_field, $created_by_id_field="item_cre
 
 	$list = array_unique($list);
 
-	return " ($mod_id_field in (".implode(",",$list).") OR $created_by_id_field=".$AppUI->user_id.") ";
+	return " ($mod_id_field in (".implode(",",$list).") OR $created_by_id_field=".$AppUI->user_id." OR item_public=1) ";
 }
 ?>

--- a/modules/bugspray/setup.php
+++ b/modules/bugspray/setup.php
@@ -3,7 +3,7 @@
 /* Help Desk module definitions */
 $config = array();
 $config['mod_name'] = 'HelpDesk';
-$config['mod_version'] = '0.2';
+$config['mod_version'] = '0.3';
 $config['mod_directory'] = 'helpdesk';
 $config['mod_setup_class'] = 'CSetupHelpDesk';
 $config['mod_type'] = 'user';
@@ -37,6 +37,7 @@ class CSetupHelpDesk {
 			  `item_assigned_to` int(11) NOT NULL default '0',
 			  `item_created_by` int(11) NOT NULL default '0',
 			  `item_notify` int(1) DEFAULT '1' NOT NULL ,
+			  `item_public` tinyint(1) DEFAULT '0' NOT NULL,
 			  `item_requestor` varchar(48) NOT NULL default '',
 			  `item_requestor_id` int(11) NOT NULL default '0',
 			  `item_requestor_email` varchar(128) NOT NULL default '',
@@ -190,6 +191,9 @@ class CSetupHelpDesk {
 			LIMIT 1";
 
 		db_exec($sql);
+		break;
+	      case "0.2":
+		$bulk_sql[] = "ALTER TABLE `helpdesk_items` ADD `item_public` tinyint(1) DEFAULT '0' NOT NULL";
 		break;
 	      default:
 		$success = 0;

--- a/modules/bugspray/view.php
+++ b/modules/bugspray/view.php
@@ -53,7 +53,7 @@ if (!db_loadHash( $sql, $hditem )) {
 
   //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
   $canReadCompany = !getDenyRead( "companies", $hditem['item_company_id'] );
-  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id){
+  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || @$hditem['item_public'] == 1){
   	$canRead = 1;
   }
 


### PR DESCRIPTION
This change implements the ability to mark Bugspray (HelpDesk) items as "Public", allowing them to be viewed by any logged-in user regardless of their company affiliation or whether they created the item.

Changes include:
- Database: Added `item_public` column to `helpdesk_items` table.
- Setup: Updated `modules/bugspray/setup.php` to increment version to 0.3 and add upgrade logic.
- Class: Added `$item_public` property to `CHelpDeskItem` and updated `getPermsWhereClause` to include public items in lists.
- UI: Added a checkbox for "Public" in `modules/bugspray/addedit.php`.
- Access Control: Updated `modules/bugspray/view.php` to grant read access if `item_public` is true.

---
*PR created automatically by Jules for task [17354815837579952332](https://jules.google.com/task/17354815837579952332) started by @davmont*