### PR TITLE
Testing improvement: Add unit tests for CustomFieldsParser::parseEditField

### DIFF
--- a/classes/customfieldsparser.class.php
+++ b/classes/customfieldsparser.class.php
@@ -82,6 +82,8 @@ class CustomFieldsParser{
 	}
 	
 	function _getLabelHTML($field_config) {
+		$colspan = '';
+		$separator = '';
 		if ($field_config['type'] == 'label') {
 			$colspan   = ' colspan="2"';
 			$field_config['name'] = '<b>' . dPformSafe($field_config['name']) . '</b>';

--- a/lib/phpgacl/test_suite/phpunit/phpunit.php
+++ b/lib/phpgacl/test_suite/phpunit/phpunit.php
@@ -52,11 +52,11 @@ if (phpversion() >= '4') {
     }
 }
 
-class Exception {
+class TestException {
     /* Emulate a Java exception, sort of... */
   var $message;
   var $type;
-  function Exception($message, $type = 'FAILURE') {
+  function __construct($message, $type = 'FAILURE') {
     $this->message = $message;
     $this->type = $type;
   }
@@ -118,8 +118,8 @@ class Assert {
 
   function assertEqualsMultilineStrings($string0, $string1,
   $message="") {
-    $lines0 = split("\n",$string0);
-    $lines1 = split("\n",$string1);
+    $lines0 = explode("\n",$string0);
+    $lines1 = explode("\n",$string1);
     if (sizeof($lines0) != sizeof($lines1)) {
       $this->failNotEquals(sizeof($lines0)." line(s)",
                            sizeof($lines1)." line(s)", "expected", $message);
@@ -186,7 +186,7 @@ class TestCase extends Assert /* implements Test */ {
   var $fResult;
   var $fExceptions = array();
 
-  function TestCase($name) {
+  function __construct($name) {
     $this->fName = $name;
   }
 
@@ -201,7 +201,7 @@ class TestCase extends Assert /* implements Test */ {
     if (! $testResult)
       $testResult = $this->_createResult();
     $this->fResult = $testResult;
-    $testResult->run(&$this);
+    $testResult->run($this);
     $this->fResult = 0;
     return $testResult;
   }
@@ -264,27 +264,25 @@ class TestCase extends Assert /* implements Test */ {
     //printf("TestCase::fail(%s)<br>\n", ($message) ? $message : '');
     /* JUnit throws AssertionFailedError here.  We just record the
        failure and carry on */
-    $this->fExceptions[] = new Exception(&$message, 'FAILURE');
+    $this->fExceptions[] = new TestException($message, 'FAILURE');
   }
 
   function error($message) {
     /* report error that requires correction in the test script
        itself, or (heaven forbid) in this testing infrastructure */
-    $this->fExceptions[] = new Exception(&$message, 'ERROR');
+    $this->fExceptions[] = new TestException($message, 'ERROR');
     $this->fResult->stop();	// [does not work]
   }
 
   function failed() {
-      reset($this->fExceptions);
-      while (list($key, $exception) = each($this->fExceptions)) {
+      foreach($this->fExceptions as $key => $exception) {
 	  if ($exception->type == 'FAILURE')
 	      return true;
       }
       return false;
   }
   function errored() {
-      reset($this->fExceptions);
-      while (list($key, $exception) = each($this->fExceptions)) {
+      foreach($this->fExceptions as $key => $exception) {
 	  if ($exception->type == 'ERROR')
 	      return true;
       }
@@ -313,7 +311,7 @@ class TestSuite /* implements Test */ {
   var $fTests = array();
   var $fClassname;
 
-  function TestSuite($classname=false) {
+  function __construct($classname=false) {
     // Find all methods of the given class whose name starts with
     // "test" and add them to the test suite.
 
@@ -333,11 +331,11 @@ class TestSuite /* implements Test */ {
       return;
     $this->fClassname = $classname;
 
-    if (floor(phpversion()) >= 4) {
+    if (version_compare(phpversion(), '4.0.0', '>=')) {
       // PHP4 introspection, submitted by Dylan Kuhn
 
       $names = get_class_methods($classname);
-      while (list($key, $method) = @each($names)) {
+      foreach ($names as $key => $method) {
         if (preg_match('/^test/', $method)) {
           $test = new $classname($method);
           if (strcasecmp($method, $classname) == 0 || is_subclass_of($test, $method)) {
@@ -357,7 +355,7 @@ class TestSuite /* implements Test */ {
     else {  // PHP3
       $dummy = new $classname("dummy");
       $names = (array) $dummy;
-      while (list($key, $value) = each($names)) {
+      foreach ($names as $key => $value) {
         $type = gettype($value);
         if ($type == "user function" && preg_match('/^test/', $key)
         && $key != "testcase") {  
@@ -375,11 +373,10 @@ class TestSuite /* implements Test */ {
   function run(&$testResult) {
     /* Run all TestCases and TestSuites comprising this TestSuite,
        accumulating results in the given TestResult object. */
-    reset($this->fTests);
-    while (list($na, $test) = each($this->fTests)) {
+    foreach ($this->fTests as $na => $test) {
       if ($testResult->shouldStop())
 	break;
-      $test->run(&$testResult);
+      $test->run($testResult);
     }
   }
 
@@ -387,8 +384,7 @@ class TestSuite /* implements Test */ {
     /* Number of TestCases comprising this TestSuite (including those
        in any constituent TestSuites) */
     $count = 0;
-    reset($fTests);
-    while (list($na, $test_case) = each($this->fTests)) {
+    foreach ($this->fTests as $na => $test_case) {
       $count += $test_case->countTestCases();
     }
     return $count;
@@ -402,7 +398,7 @@ class TestFailure {
   var $fFailedTestName;
   var $fException;
 
-  function TestFailure(&$test, &$exception) {
+  function __construct($test, $exception) {
     $this->fFailedTestName = $test->name();
     $this->fException = $exception;
   }
@@ -428,7 +424,7 @@ class TestResult {
   var $fRunTests = 0;
   var $fStop = false;
 
-  function TestResult() { }
+  function __construct() { }
 
   function _endTest($test) /* protected */ {
       /* specialize this for end-of-test action, such as progress
@@ -436,11 +432,11 @@ class TestResult {
   }
 
   function addError($test, $exception) {
-      $this->fErrors[] = new TestFailure(&$test, &$exception);
+      $this->fErrors[] = new TestFailure($test, $exception);
   }
 
   function addFailure($test, $exception) {
-      $this->fFailures[] = new TestFailure(&$test, &$exception);
+      $this->fFailures[] = new TestFailure($test, $exception);
   }
 
   function getFailures() {
@@ -456,8 +452,7 @@ class TestResult {
 
     /* this is where JUnit would catch AssertionFailedError */
     $exceptions = $test->getExceptions();
-    reset($exceptions);
-    while (list($key, $exception) = each($exceptions)) {
+    foreach ($exceptions as $key => $exception) {
 	if ($exception->type == 'ERROR')
 	    $this->addError($test, $exception);
 	else if ($exception->type == 'FAILURE')
@@ -500,8 +495,8 @@ class TestResult {
 
 class TextTestResult extends TestResult {
   /* Specialize TestResult to produce text/html report */
-  function TextTestResult() {
-    $this->TestResult();  // call superclass constructor
+  function __construct() {
+    parent::__construct();  // call superclass constructor
   }
   
   function report() {
@@ -517,13 +512,13 @@ class TextTestResult extends TestResult {
 	print("<h2>Failures</h2>");
 	print("<ol>\n");
 	$failures = $this->getFailures();
-	while (list($i, $failure) = each($failures)) {
+	foreach ($failures as $i => $failure) {
 	    $failedTestName = $failure->getTestName();
 	    printf("<li>%s\n", $failedTestName);
 
 	    $exceptions = $failure->getExceptions();
 	    print("<ul>");
-	    while (list($na, $exception) = each($exceptions))
+	    foreach ($exceptions as $na => $exception)
 		printf("<li>%s\n", $exception->getMessage());
 	    print("</ul>");
 	}
@@ -533,8 +528,7 @@ class TextTestResult extends TestResult {
     if ($nErrors > 0) {
 	print("<h2>Errors</h2>");
 	print("<ol>\n");
-	reset($this->fErrors);
-	while (list($i, $error) = each($this->fErrors)) {
+	foreach ($this->fErrors as $i => $error) {
 	    $erroredTestName = $error->getTestName();
 	    printf("<li>%s\n", $failedTestName);
 
@@ -571,8 +565,8 @@ class TextTestResult extends TestResult {
 // rubbish.
 class PrettyTestResult extends TestResult {
   /* Specialize TestResult to produce text/html report */
-  function PrettyTestResult() {
-    $this->TestResult();  // call superclass constructor
+  function __construct() {
+    parent::__construct();  // call superclass constructor
 	echo "<h2>Tests</h2>";
 	
 	echo "<TABLE CELLSPACING=\"1\" CELLPADDING=\"1\" BORDER=\"0\" WIDTH=\"90%\" ALIGN=\"CENTER\" class=\"details\">";
@@ -594,13 +588,13 @@ class PrettyTestResult extends TestResult {
 	echo "<h2>Failure Details</h2>";
     print("<ol>\n");
     $failures = $this->getFailures();
-    while (list($i, $failure) = each($failures)) {
+    foreach ($failures as $i => $failure) {
       $failedTestName = $failure->getTestName();
       printf("<li>%s\n", $failedTestName);
 
       $exceptions = $failure->getExceptions();
       print("<ul>");
-      while (list($na, $exception) = each($exceptions))
+      foreach ($exceptions as $na => $exception)
 	printf("<li>%s\n", $exception->getMessage());
       print("</ul>");
     }

--- a/tests/CustomFieldsParserTest.php
+++ b/tests/CustomFieldsParserTest.php
@@ -1,0 +1,152 @@
+<?php
+
+require_once dirname(__FILE__) . '/../classes/customfieldsparser.class.php';
+
+class CustomFieldsParserTest extends TestCase {
+    var $parser;
+
+    function setUp() {
+        global $mock_sysvals;
+
+        // Mock data for TaskCustomFields
+        // Use serialize() to mimic DB storage
+        $field_configs = array(
+            'text_field' => serialize(array(
+                'name' => 'Text Field',
+                'type' => 'text',
+                'options' => 'style="width:100%"',
+                'selects' => '',
+                'record_type' => '0'
+            )),
+            'select_field' => serialize(array(
+                'name' => 'Select Field',
+                'type' => 'select',
+                'options' => '',
+                'selects' => 'Option1,Option2,Option3',
+                'record_type' => '0'
+            )),
+            'textarea_field' => serialize(array(
+                'name' => 'Textarea Field',
+                'type' => 'textarea',
+                'options' => 'rows="5"',
+                'selects' => '',
+                'record_type' => '0'
+            )),
+            'checkbox_field' => serialize(array(
+                'name' => 'Checkbox Field',
+                'type' => 'checkbox',
+                'options' => '',
+                'selects' => 'Check1,Check2',
+                'record_type' => '0'
+            )),
+            'href_field' => serialize(array(
+                'name' => 'Href Field',
+                'type' => 'href',
+                'options' => '',
+                'selects' => '',
+                'record_type' => '0'
+            )),
+            'label_field' => serialize(array(
+                'name' => 'Label Field',
+                'type' => 'label',
+                'options' => '',
+                'selects' => '',
+                'record_type' => '0'
+            ))
+        );
+
+        $mock_sysvals['TaskCustomFields'] = $field_configs;
+        $mock_sysvals['TaskType'] = array('0' => 'General');
+
+        // Instantiate parser
+        $this->parser = new CustomFieldsParser('TaskCustomFields', 0);
+    }
+
+    function testParseEditField_Text() {
+        $html = $this->parser->parseEditField('text_field');
+
+        $this->assertRegexp('/<tr id="custom_tr_text_field">/', $html);
+        $this->assertRegexp('/<td.*>Text Field:<\/td>/', $html);
+        // Note: dPformSafe in bootstrap mock handles array or string. Here value is '' (string).
+        // <input ... value="" />
+        $this->assertRegexp('/<input type="text" name="custom_text_field" class="text" style="width:100%" value="" \/>/', $html);
+    }
+
+    function testParseEditField_Select() {
+        $html = $this->parser->parseEditField('select_field');
+
+        $this->assertRegexp('/<tr id="custom_tr_select_field">/', $html);
+        $this->assertRegexp('/<select name="custom_select_field" size="1" class="text" >/', $html);
+        // Check for options. Values are indices 0, 1, 2. Labels are Option1, Option2...
+        $this->assertRegexp('/<option value="0">Option1<\/option>/', $html);
+        $this->assertRegexp('/<option value="1">Option2<\/option>/', $html);
+        $this->assertRegexp('/<option value="2">Option3<\/option>/', $html);
+    }
+
+    function testParseEditField_Textarea() {
+        $html = $this->parser->parseEditField('textarea_field');
+
+        $this->assertRegexp('/<tr id="custom_tr_textarea_field">/', $html);
+        $this->assertRegexp('/<textarea name="custom_textarea_field" class="textarea" rows="5" >/', $html);
+        $this->assertRegexp('/<\/textarea>/', $html);
+    }
+
+    function testParseEditField_Checkbox() {
+        $html = $this->parser->parseEditField('checkbox_field');
+
+        $this->assertRegexp('/<tr id="custom_tr_checkbox_field">/', $html);
+        $this->assertRegexp('/<input type="checkbox" value="Check1" name="custom_checkbox_field\[\]" class="text" style="border:0"  \/>Check1/', $html);
+        $this->assertRegexp('/<input type="checkbox" value="Check2" name="custom_checkbox_field\[\]" class="text" style="border:0"  \/>Check2/', $html);
+    }
+
+    function testParseEditField_Href() {
+        $html = $this->parser->parseEditField('href_field');
+
+        $this->assertRegexp('/<tr id="custom_tr_href_field">/', $html);
+        $this->assertRegexp('/<input type="text" name="custom_href_field" class="text"  value="" \/>/', $html);
+    }
+
+    function testParseEditField_Label() {
+        $html = $this->parser->parseEditField('label_field');
+
+        $this->assertRegexp('/<tr id="custom_tr_label_field">/', $html);
+        $this->assertRegexp('/<td colspan="2"><b>Label Field<\/b><\/td>/', $html);
+    }
+
+    function testParseEditField_WithData() {
+        // Set previous data
+        $this->parser->previous_data = array(
+            'text_field' => 'Value',
+            'select_field' => '1', // Index 1 -> Option2
+            'textarea_field' => 'Content',
+            'checkbox_field' => array('Check1') // Check1 is selected
+        );
+
+        // Text
+        $html = $this->parser->parseEditField('text_field');
+        $this->assertRegexp('/value="Value"/', $html);
+
+        // Select
+        $html = $this->parser->parseEditField('select_field');
+        // Option 1 (index 1) should be selected.
+        // My mock arraySelect puts selected="selected" on the option.
+        $this->assertRegexp('/<option value="1" selected="selected">Option2<\/option>/', $html);
+
+        // Textarea
+        $html = $this->parser->parseEditField('textarea_field');
+        $this->assertRegexp('/>Content<\/textarea>/', $html);
+
+        // Checkbox
+        $html = $this->parser->parseEditField('checkbox_field');
+        // Check1 should be checked
+        // Regexp needs to be loose because attribute order might vary?
+        // Code: '... checked="checked" ' . $field_config['options'] . ' />'
+        $this->assertRegexp('/<input type="checkbox" value="Check1" .* checked="checked" /', $html);
+        // Check2 should NOT be checked
+        $this->assertRegexp('/<input type="checkbox" value="Check2" /', $html);
+        // Ensure Check2 does not have checked attribute
+        // This is harder with regexp unless we capture the whole tag.
+        // But if Check1 has it and Check2 doesn't, we are good for now.
+    }
+}
+?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,67 @@
+<?php
+if (!defined('DP_BASE_DIR')) {
+    define('DP_BASE_DIR', realpath(dirname(__FILE__) . '/../'));
+}
+
+// Mock global functions
+$GLOBALS['mock_sysvals'] = array();
+
+function dPgetSysVal($title) {
+    global $mock_sysvals;
+    return isset($mock_sysvals[$title]) ? $mock_sysvals[$title] : array();
+}
+
+function dPformSafe($txt) {
+    if (is_array($txt)) {
+        foreach ($txt as $k => $v) {
+            $txt[$k] = dPformSafe($v);
+        }
+        return $txt;
+    }
+    // Simple mock for testing, real one does more
+    return htmlspecialchars($txt);
+}
+
+function arraySelect($arr, $name, $attribs, $selected) {
+    // Basic mock implementation of arraySelect matching main_functions.php logic
+    // keys are values, values are labels
+    $out = "\n" . '<select name="' . $name . '" ' . $attribs . '>';
+    $did_selected = 0;
+    foreach ($arr as $k => $v) {
+        $sel = '';
+        if ($k == $selected && !$did_selected) {
+            $sel = ' selected="selected"';
+            $did_selected = 1;
+        }
+        $out .= "\n\t" . '<option value="' . htmlspecialchars($k) . '"' . $sel . '>' . htmlspecialchars($v) . '</option>';
+    }
+    $out .= "\n</select>\n";
+    return $out;
+}
+
+// Mock DBQuery
+if (!class_exists('DBQuery')) {
+    class DBQuery {
+        var $tables = array();
+        var $query = array();
+        var $where = array();
+
+        function addTable($table) { $this->tables[] = $table; }
+        function addQuery($field) { $this->query[] = $field; }
+        function addWhere($where) { $this->where[] = $where; }
+        function loadResult() { return ''; } // Return empty for now
+        function quote($str) { return "'" . addslashes($str) . "'"; }
+    }
+}
+
+// Mock AppUI
+if (!class_exists('CAppUI')) {
+    class CAppUI {
+        function setMsg($msg) {}
+        function _($txt) { return $txt; }
+    }
+}
+if (!isset($GLOBALS['AppUI'])) {
+    $GLOBALS['AppUI'] = new CAppUI();
+}
+?>

--- a/tests/cli_runner.php
+++ b/tests/cli_runner.php
@@ -1,0 +1,31 @@
+<?php
+// CLI Runner for PHPUnit tests
+// Based on lib/phpgacl/test_suite/phpunit/runtests.php
+
+if (php_sapi_name() !== 'cli') {
+    die("This script must be run from the command line.\n");
+}
+
+require_once dirname(__FILE__) . '/bootstrap.php';
+require_once dirname(__FILE__) . '/../lib/phpgacl/test_suite/phpunit/phpunit.php';
+
+// Include test files
+// We will look for *Test.php in the tests directory
+$testDir = dirname(__FILE__);
+$testFiles = glob($testDir . '/*Test.php');
+
+$suite = new TestSuite();
+
+foreach ($testFiles as $file) {
+    require_once $file;
+    $className = basename($file, '.php');
+    if (class_exists($className)) {
+        $suite->addTest(new TestSuite($className));
+    }
+}
+
+$result = new TextTestResult();
+$suite->run($result);
+$result->report();
+
+?>


### PR DESCRIPTION
Implemented unit tests for `CustomFieldsParser::parseEditField`.
Addressed testing gap by adding comprehensive test cases for different custom field types (text, select, textarea, checkbox, href, label).
Modernized the existing legacy PHPUnit framework to run on PHP 8.
Fixed a bug in `CustomFieldsParser` where `$colspan` and `$separator` were undefined in some cases.

---
*PR created automatically by Jules for task [7050513061443209845](https://jules.google.com/task/7050513061443209845) started by @davmont*