### PR TITLE
⚡ Optimize Task Notifications by Offloading to EventQueue

### DIFF
--- a/modules/tasks/do_updatetask.php
+++ b/modules/tasks/do_updatetask.php
@@ -106,7 +106,7 @@ $new_task_end = new CDate($task->task_end_date);
 if ($new_task_end->dateDiff($task_end_date)) {
 	$task->addReminder();
 }
-if ($notify_owner && $msg = $task->notifyOwner()) {
+if ($notify_owner && $msg = $task->notifyOwner($obj->task_log_description)) {
 	$AppUI->setMsg($msg, UI_MSG_ERROR);
 }
 


### PR DESCRIPTION
This PR improves the performance of task updates and notifications by offloading the email sending process to the system's `EventQueue`.

Previously, `CTask::notify` and `CTask::notifyOwner` sent emails synchronously, which could block the user interface, especially with multiple recipients or slow SMTP servers.

Changes:
1.  Refactored `modules/tasks/tasks.class.php`:
    *   Renamed original `notify` to `sendNotifyEmail`.
    *   Renamed original `notifyOwner` to `sendNotifyOwnerEmail`.
    *   Created new `notify` and `notifyOwner` methods that add an event to the `event_queue` table.
    *   Added `processNotify` and `processNotifyOwner` methods to be called by the queue processor (`queuescanner.php`).
    *   Added `restoreUserContext` helper to restore the initiating user's context (locale, preferences) when running in the background.
2.  Updated `modules/tasks/do_updatetask.php` to pass the task log description explicitly to `notifyOwner`, removing the dependency on `$_POST` within the notification logic (as `$_POST` is unavailable in the background queue).

This change ensures that the user interface returns immediately after a task update, while emails are processed asynchronously by the queue scanner.

---
*PR created automatically by Jules for task [8804858996557452663](https://jules.google.com/task/8804858996557452663) started by @davmont*