### PR TITLE
Fix infinite loops in tasks organizer due to circular dependencies

### DIFF
--- a/modules/tasks/organizer.php
+++ b/modules/tasks/organizer.php
@@ -227,10 +227,16 @@ function get_last_children($task) {
 	return $arr;
 }
 
-function process_dependencies($i) {
+function process_dependencies($i, $visited = array()) {
 	global $tasks, $option_advance_if_possible;
 
 	if ($tasks[$i]["fixed"]) return;  
+
+	if (in_array($tasks[$i]["task_id"], $visited)) {
+		log_error("Circular dependency detected: Task " . $tasks[$i]["task_name"] . " depends on itself indirectly.");
+		return;
+	}
+	$visited[] = $tasks[$i]["task_id"];
 
 	log_info("<div style='padding-left: 1em'>Dependecies for '" . $tasks[$i]["task_name"] . "':<br />");
 
@@ -281,7 +287,7 @@ function process_dependencies($i) {
 
 			// TODO: Detect dependencies loops (A->B, B->C, C->A)
 
-			process_dependencies($index);
+			process_dependencies($index, $visited);
 
 			if (!$tasks[$index]["fixed"]) {
 				$all_fixed = false;
@@ -298,9 +304,9 @@ function process_dependencies($i) {
 				} else {
 					log_info("this task is complete => don't check dependency");
 				}
-				$d++;
 			}
-		}	   
+			$d++;
+		}
 
 		if ($all_fixed) {
 			// this task depends only on fixated tasks


### PR DESCRIPTION
Implemented cycle detection in `modules/tasks/organizer.php` by adding a `$visited` array to the `process_dependencies` function. This prevents infinite recursion when task dependencies form a loop. Additionally, fixed a bug where the loop counter `$d` was not incremented when a dependency could not be fixed, which could also lead to an infinite loop. Verified the fix using a reproduction script and syntax checks.

---
*PR created automatically by Jules for task [10948313872916621193](https://jules.google.com/task/10948313872916621193) started by @davmont*