### PR TITLE
Refactor deprecated preg_replace /e in filter.php

### DIFF
--- a/includes/filter.php
+++ b/includes/filter.php
@@ -304,10 +304,10 @@ function decode_entities($text, $exclude = array()) {
   $exclude = array_flip($exclude);
 
   // Use a regexp to select all entities in one pass, to avoid decoding 
-  // double-escaped entities twice. The PREG_REPLACE_EVAL modifier 'e' is
-  // being used to allow for a callback (see 
-  // http://php.net/manual/en/reference.pcre.pattern.modifiers).
-  return preg_replace('/&(#x?)?([A-Za-z0-9]+);/e', '_decode_entities("$1", "$2", "$0", $html_entities, $exclude)', $text);
+  // double-escaped entities twice.
+  return preg_replace_callback('/&(#x?)?([A-Za-z0-9]+);/', function($matches) use (&$html_entities, &$exclude) {
+    return _decode_entities($matches[1], $matches[2], $matches[0], $html_entities, $exclude);
+  }, $text);
 }
 
 /**


### PR DESCRIPTION
Replaced deprecated `preg_replace` with `/e` modifier in `includes/filter.php` with `preg_replace_callback`.
Verified with reproduction script and existing tests.

---
*PR created automatically by Jules for task [4677897626804222801](https://jules.google.com/task/4677897626804222801) started by @davmont*