### PR TITLE
Activate new permissions check in History module

### DIFF
--- a/modules/history/index.php
+++ b/modules/history/index.php
@@ -241,6 +241,7 @@ echo $AppUI->_('Add history'); ?>" onclick="window.location='?m=history&amp;a=ad
 	<th nowrap="nowrap"><?php echo $AppUI->_('User'); ?>&nbsp;&nbsp;</th>
   </tr>
 <?php
+$perms =& $AppUI->acl();
 foreach ($history as $row) {
 	$mod_table = $row['history_table'];
 	$module = (($mod_table == 'task_log') ? 'tasks' : $filter_module_tables[$mod_table]);
@@ -249,10 +250,9 @@ foreach ($history as $row) {
 	$tf = $AppUI->getPref('TIMEFORMAT');
 	$hd = new Date($row['history_date']);
 	// Checking permissions.
-	// TODO: Enable the lines below to activate new permissions.
 	if ($mod_table == 'login' || $mod_table == 'history' 
 		|| !(in_array($mod_table, $filter_module_tables))
-	    || getPermission($module, 'access', $row['history_item'])) {
+	    || $perms->checkModuleItem($module, 'view', $row['history_item'])) {
 ?>
   <tr>	
 	<td><a href="?m=history&amp;a=addedit&amp;history_id=<?php echo ($row['history_id']); ?>">


### PR DESCRIPTION
Updated modules/history/index.php to use the new permission system via `$perms->checkModuleItem()` instead of the legacy `getPermission()` wrapper. This enables item-level view permissions for history items as originally intended by the TODO comment.

Key changes:
- Initialized `$perms = $AppUI->acl()` in the history loop context.
- Replaced `getPermission($module, 'access', $item_id)` with `$perms->checkModuleItem($module, 'view', $item_id)`.
- Removed the TODO comment.

---
*PR created automatically by Jules for task [1376179853288500626](https://jules.google.com/task/1376179853288500626) started by @davmont*