### PR TITLE
Refactor deprecated mysql_pconnect checks in login/lostpass pages

### DIFF
--- a/includes/main_functions.php
+++ b/includes/main_functions.php
@@ -1015,9 +1015,6 @@ function dPcheckLoginSystem()
 {
 	global $AppUI;
 	$msg = '<span class="error">' . $AppUI->getMsg() . '</span>';
-
-	$msg .= phpversion() < '4.1' ? '<br /><span class="warning">WARNING: dotproject is NOT SUPPORT for this PHP Version (' . phpversion() . ')</span>' : '';
-	$msg .= function_exists('mysql_pconnect') ? '' : '<br /><span class="warning">WARNING: PHP may not be compiled with MySQL support.  This will prevent proper operation of dotProject.  Please check you system setup.</span>';
 	return $msg;
 }
 ?>

--- a/style/amp/login.php
+++ b/style/amp/login.php
@@ -52,7 +52,7 @@
 			<div align="center"><span style="font-size:7pt">Version <?php echo @$AppUI->getVersion();?></span></div>
 			<?php } ?>
 </form>
-<div align="center" style="font-size:9px;"><?php echo '<span class="error">'.$AppUI->getMsg().'</span>'; $msg = ''; $msg .=  phpversion() < '4.1' ? '<br /><span class="warning">WARNING: dotproject is NOT SUPPORT for this PHP Version ('.phpversion().')</span>' : ''; $msg .= function_exists( 'mysql_pconnect' ) ? '': '<br /><span class="warning">WARNING: PHP may not be compiled with MySQL support.  This will prevent proper operation of dotProject.  Please check you system setup.</span>'; echo $msg; ?></div>
+<div align="center" style="font-size:9px;"><?php echo dPcheckLoginSystem(); ?></div>
 <center>
 <div style="font-size:10px;color:#999999; width:250px;">
 <?php echo "* ".$AppUI->_("You must have cookies enabled in your browser"); ?>

--- a/style/amp/lostpass.php
+++ b/style/amp/lostpass.php
@@ -50,7 +50,7 @@
 			<div align="center"> <span style="font-size:7pt">Version <?php echo @$AppUI->getVersion();?></span> </div>
 			<?php } ?>
 </form>
-<div align="center"><?php echo '<span class="error">'.$AppUI->getMsg().'</span>'; $msg = ''; $msg .= phpversion() < '4.1' ? '<br /><span class="warning">WARNING: dotproject is NOT SUPPORT for this PHP Version ('.phpversion().')</span>' : ''; $msg .= function_exists( 'mysql_pconnect' ) ? '': '<br /><span class="warning">WARNING: PHP may not be compiled with MySQL support.  This will prevent proper operation of dotProject.  Please check you system setup.</span>'; echo $msg; ?></div>
+<div align="center"><?php echo dPcheckLoginSystem(); ?></div>
 </td>
 <td bgcolor="#FFFFFF" width="8px"></td>
 </tr>

--- a/style/default/lostpass.php
+++ b/style/default/lostpass.php
@@ -49,12 +49,7 @@ if (!defined('DP_BASE_DIR')) {
 </form>
 <div align="center">
 <?php
-	echo '<span class="error">'.$AppUI->getMsg().'</span>';
-
-	$msg = '';
-	$msg .=  phpversion() < '4.1' ? '<br /><span class="warning">WARNING: dotproject is NOT SUPPORT for this PHP Version ('.phpversion().')</span>' : '';
-	$msg .= function_exists('mysql_pconnect') ? '': '<br /><span class="warning">WARNING: PHP may not be compiled with MySQL support.  This will prevent proper operation of dotProject.  Please check you system setup.</span>';
-	echo $msg;
+	echo dPcheckLoginSystem();
 ?>
 </div>
 </body>

--- a/style/dp-grey-theme/lostpass.php
+++ b/style/dp-grey-theme/lostpass.php
@@ -46,12 +46,7 @@
 </form>
 <div align="center">
 <?php
-	echo '<span class="error">'.$AppUI->getMsg().'</span>';
-
-	$msg = '';
-	$msg .=  phpversion() < '4.1' ? '<br /><span class="warning">WARNING: dotproject is NOT SUPPORT for this PHP Version ('.phpversion().')</span>' : '';
-	$msg .= function_exists('mysql_pconnect') ? '': '<br /><span class="warning">WARNING: PHP may not be compiled with MySQL support.  This will prevent proper operation of dotProject.  Please check you system setup.</span>';
-	echo $msg;
+	echo dPcheckLoginSystem();
 ?>
 </div>
 </body>

--- a/style/material/lostpass.php
+++ b/style/material/lostpass.php
@@ -49,12 +49,7 @@ if (!defined('DP_BASE_DIR')) {
 </form>
 <div align="center">
 <?php
-	echo '<span class="error">'.$AppUI->getMsg().'</span>';
-
-	$msg = '';
-	$msg .=  phpversion() < '4.1' ? '<br /><span class="warning">WARNING: dotproject is NOT SUPPORT for this PHP Version ('.phpversion().')</span>' : '';
-	$msg .= function_exists('mysql_pconnect') ? '': '<br /><span class="warning">WARNING: PHP may not be compiled with MySQL support.  This will prevent proper operation of dotProject.  Please check you system setup.</span>';
-	echo $msg;
+	echo dPcheckLoginSystem();
 ?>
 </div>
 </body>

--- a/style/wps-redmond/lostpass.php
+++ b/style/wps-redmond/lostpass.php
@@ -46,12 +46,7 @@
 </form>
 <div align="center">
 <?php
-	echo '<span class="error">'.$AppUI->getMsg().'</span>';
-
-	$msg = '';
-	$msg .=  phpversion() < '4.1' ? '<br /><span class="warning">WARNING: dotproject is NOT SUPPORT for this PHP Version ('.phpversion().')</span>' : '';
-	$msg .= function_exists( 'mysql_pconnect' ) ? '': '<br /><span class="warning">WARNING: PHP may not be compiled with MySQL support.  This will prevent proper operation of dotProject.  Please check you system setup.</span>';
-	echo $msg;
+	echo dPcheckLoginSystem();
 ?>
 </div>
 </body>


### PR DESCRIPTION
This change removes deprecated `mysql_pconnect` and PHP version checks from the `dPcheckLoginSystem` function and various theme files. These checks were causing false positive warnings on modern PHP environments where `mysql` extension is removed but `mysqli` or `PDO` is used. The logic is centralized in `dPcheckLoginSystem` and theme files are updated to use this function.

---
*PR created automatically by Jules for task [785110678856101610](https://jules.google.com/task/785110678856101610) started by @davmont*