### PR TITLE
Implement Custom Fields ordering and data type validation

### DIFF
--- a/classes/CustomFields.class.php
+++ b/classes/CustomFields.class.php
@@ -14,13 +14,10 @@ require_once($AppUI->getModuleClass('files'));
 class CustomField
 {
 	public $field_id;
-	// TODO - Implement Field Order - some people like to change the order of fields
 	public $field_order;
 	public $field_name;
 	public $field_description;
 	public $field_htmltype;
-	// TODO - data type, meant for validation if you just want numeric data in a text input
-	// but not yet implemented
 	public $field_datatype;
 
 	public $field_extratags;
@@ -37,13 +34,25 @@ class CustomField
 		$field_name,
 		$field_order,
 		$field_description,
-		$field_extratags
+		$field_extratags,
+		$field_datatype = 'alpha'
 	) {
 		$this->field_id = $field_id;
 		$this->field_name = $field_name;
 		$this->field_order = $field_order;
 		$this->field_description = stripslashes($field_description);
 		$this->field_extratags = stripslashes($field_extratags);
+		$this->field_datatype = $field_datatype;
+	}
+
+	function validate()
+	{
+		if ($this->field_datatype == 'numeric' && $this->value_charvalue != '') {
+			if (!is_numeric($this->value_charvalue)) {
+				return 'Field ' . $this->field_name . ' must be numeric';
+			}
+		}
+		return true;
 	}
 
 	function load($object_id)
@@ -185,14 +194,16 @@ class CustomFieldCheckBox extends CustomField
 		$field_name,
 		$field_order,
 		$field_description,
-		$field_extratags
+		$field_extratags,
+		$field_datatype = 'alpha'
 	) {
 		parent::__construct(
 			$field_id,
 			$field_name,
 			$field_order,
 			$field_description,
-			$field_extratags
+			$field_extratags,
+			$field_datatype
 		);
 		$this->field_htmltype = 'checkbox';
 	}
@@ -230,14 +241,16 @@ class CustomFieldText extends CustomField
 		$field_name,
 		$field_order,
 		$field_description,
-		$field_extratags
+		$field_extratags,
+		$field_datatype = 'alpha'
 	) {
 		parent::__construct(
 			$field_id,
 			$field_name,
 			$field_order,
 			$field_description,
-			$field_extratags
+			$field_extratags,
+			$field_datatype
 		);
 		$this->field_htmltype = 'textinput';
 	}
@@ -269,14 +282,16 @@ class CustomFieldTextArea extends CustomField
 		$field_name,
 		$field_order,
 		$field_description,
-		$field_extratags
+		$field_extratags,
+		$field_datatype = 'alpha'
 	) {
 		parent::__construct(
 			$field_id,
 			$field_name,
 			$field_order,
 			$field_description,
-			$field_extratags
+			$field_extratags,
+			$field_datatype
 		);
 		$this->field_htmltype = 'textarea';
 	}
@@ -308,14 +323,16 @@ class CustomFieldLabel extends CustomField
 		$field_name,
 		$field_order,
 		$field_description,
-		$field_extratags
+		$field_extratags,
+		$field_datatype = 'alpha'
 	) {
 		parent::__construct(
 			$field_id,
 			$field_name,
 			$field_order,
 			$field_description,
-			$field_extratags
+			$field_extratags,
+			$field_datatype
 		);
 		$this->field_htmltype = 'label';
 	}
@@ -340,14 +357,16 @@ class CustomFieldSeparator extends CustomField
 		$field_name,
 		$field_order,
 		$field_description,
-		$field_extratags
+		$field_extratags,
+		$field_datatype = 'alpha'
 	) {
 		parent::__construct(
 			$field_id,
 			$field_name,
 			$field_order,
 			$field_description,
-			$field_extratags
+			$field_extratags,
+			$field_datatype
 		);
 		$this->field_htmltype = 'separator';
 	}
@@ -372,14 +391,16 @@ class CustomFieldSelect extends CustomField
 		$field_name,
 		$field_order,
 		$field_description,
-		$field_extratags
+		$field_extratags,
+		$field_datatype = 'alpha'
 	) {
 		parent::__construct(
 			$field_id,
 			$field_name,
 			$field_order,
 			$field_description,
-			$field_extratags
+			$field_extratags,
+			$field_datatype
 		);
 		$this->field_htmltype = 'select';
 		$this->options = new CustomOptionList($field_id);
@@ -426,14 +447,16 @@ class CustomFieldWeblink extends CustomField
 		$field_name,
 		$field_order,
 		$field_description,
-		$field_extratags
+		$field_extratags,
+		$field_datatype = 'alpha'
 	) {
 		parent::__construct(
 			$field_id,
 			$field_name,
 			$field_order,
 			$field_description,
-			$field_extratags
+			$field_extratags,
+			$field_datatype
 		);
 		$this->field_htmltype = 'href';
 	}
@@ -471,9 +494,22 @@ class CustomFieldWeblink extends CustomField
 class CustomFieldFilelink extends CustomField
 {
 
-	function CustomFieldFilelink($field_id, $field_name, $field_order, $field_description, $field_extratags)
-	{
-		parent::__construct($field_id, $field_name, $field_order, $field_description, $field_extratags);
+	function CustomFieldFilelink(
+		$field_id,
+		$field_name,
+		$field_order,
+		$field_description,
+		$field_extratags,
+		$field_datatype = 'alpha'
+	) {
+		parent::__construct(
+			$field_id,
+			$field_name,
+			$field_order,
+			$field_description,
+			$field_extratags,
+			$field_datatype
+		);
 		$this->field_htmltype = 'file';
 	}
 
@@ -603,7 +639,7 @@ class CustomFields
 		$q = new DBQuery;
 		$q->addTable('custom_fields_struct');
 		$q->addWhere("field_module = '" . $this->m . "' AND field_page = '" . $this->a . "'");
-		//$q->addOrder('field_order DESC');
+		$q->addOrder('field_order ASC');
 		$q->addOrder('field_name ASC');//to display by name and not by entry in database
 		$rows = $q->loadList();
 		if ($rows != NULL) {
@@ -640,7 +676,8 @@ class CustomFields
 					$field_name,
 					$row['field_order'],
 					stripslashes($row['field_description']),
-					stripslashes($row['field_extratags'])
+					stripslashes($row['field_extratags']),
+					$row['field_datatype']
 				);
 			}
 
@@ -659,12 +696,12 @@ class CustomFields
 		$field_htmltype,
 		$field_datatype,
 		$field_extratags,
-		&$error_msg
+		&$error_msg,
+		$field_order = 1
 	) {
 		global $db;
 		$next_id = $db->GenID('custom_fields_struct_id', 1);
 
-		$field_order = 1;
 		$field_a = 'addedit';
 
 		// TODO - module pages other than addedit
@@ -698,7 +735,8 @@ class CustomFields
 		$field_htmltype,
 		$field_datatype,
 		$field_extratags,
-		&$error_msg
+		&$error_msg,
+		$field_order = 1
 	) {
 		global $db;
 
@@ -709,6 +747,7 @@ class CustomFields
 		$q->addUpdate('field_htmltype', $field_htmltype);
 		$q->addUpdate('field_datatype', $field_datatype);
 		$q->addUpdate('field_extratags', $field_extratags);
+		$q->addUpdate('field_order', $field_order);
 		$q->addWhere('field_id = ' . $field_id);
 		if (!$q->exec()) {
 			$error_msg = $db->ErrorMsg();
@@ -743,6 +782,11 @@ class CustomFields
 		if ($this->count() > 0) {
 			$store_errors = '';
 			foreach ($this->fields as $k => $cf) {
+				$validation = $this->fields[$k]->validate();
+				if ($validation !== true) {
+					$store_errors .= $validation . '<br />';
+					continue;
+				}
 				$result = $this->fields[$k]->store($object_id);
 				if ($result) {
 					$store_errors .= 'Error storing custom field ' . $k . ':' . $result;

--- a/modules/system/custom_field_addedit.php
+++ b/modules/system/custom_field_addedit.php
@@ -55,6 +55,8 @@ if (dpGetParam($_GET, 'field_id', NULL) != NULL) {
 		$field_description = $cf->fieldDescription();
 		$field_htmltype = $cf->fieldHtmlType();
 		$field_extratags = $cf->fieldExtraTags();
+		$field_order = $cf->field_order;
+		$field_datatype = $cf->field_datatype;
 		
 		if ($field_htmltype == 'select') {
 			$select_options = New CustomOptionList($field_id);
@@ -74,6 +76,8 @@ if (dpGetParam($_GET, 'field_id', NULL) != NULL) {
 	$field_description = dpGetParam($_POST, 'field_description', NULL);
 	$field_htmltype = dpGetParam($_POST, 'field_htmltype', 'textinput');
 	$field_extratags = dpGetParam($_POST, 'field_extratags', NULL);
+	$field_order = dpGetParam($_POST, 'field_order', 1);
+	$field_datatype = dpGetParam($_POST, 'field_datatype', 'alpha');
 }
 
 $html_types = Array('file' => $AppUI->_('File'),
@@ -154,6 +158,19 @@ echo htmlspecialchars($field_name)?>" onblur="this.value=this.value.replace(/[^a
 		</td><td>
 		<input type="text" name="field_description" size="40" maxlength="250" value="<?php 
 echo htmlspecialchars($field_description)?>" />
+	</td></tr>
+	<tr><td>
+		<?php echo $AppUI->_('Field Order')?>:
+		</td><td>
+		<input type="text" name="field_order" size="4" maxlength="4" value="<?php
+echo intval($field_order)?>" />
+	</td></tr>
+	<tr><td>
+		<?php echo $AppUI->_('Field Data Type')?>:
+		</td><td>
+		<?php
+echo arraySelect(array('alpha' => $AppUI->_('Text'), 'numeric' => $AppUI->_('Numeric')), 'field_datatype',
+                 'id="field_datatype"', $field_datatype); ?>
 	</td></tr>
 	<tr><td>
 		<?php echo $AppUI->_('Field Display Type')?>:

--- a/modules/system/custom_field_editor.php
+++ b/modules/system/custom_field_editor.php
@@ -33,10 +33,18 @@ foreach ($modules as $module) {
 		  . '"><img src="./images/icons/stock_new.png" align="center" width="16" height="16" border="0" alt="" />' 
 		  . $AppUI->_('Add a new Custom Field to this Module') . '</a><br /><br />');
 	echo '</td></tr>';
+
+	echo '<tr>';
+	echo '<th>' . $AppUI->_('Edit') . '</th>';
+	echo '<th>' . $AppUI->_('Delete') . '</th>';
+	echo '<th>' . $AppUI->_('Order') . '</th>';
+	echo '<th>' . $AppUI->_('Description') . '</th>';
+	echo '</tr>';
 	
 	$q->clear();
 	$q->addTable('custom_fields_struct');
 	$q->addWhere('field_module = \''.mb_strtolower($module['mod_name'])."'");
+	$q->addOrder('field_order ASC');
 	$custom_fields = $q->loadList();
 	
 	foreach ($custom_fields as $f) {
@@ -47,6 +55,8 @@ foreach ($modules as $module) {
 		echo '</td><td class="hilite">';
 		echo ('<a href="?m=system&amp;a=custom_field_addedit&amp;field_id=' . $f['field_id'] 
 			  . '&amp;delete=1"><img src="./images/icons/stock_delete-16.png" align="center" width="16" height="16" border="0" alt="" />Delete</a>');
+		echo '</td><td class="hilite">';
+		echo $f['field_order'];
 		echo '</td><td class="hilite">';
 		echo htmlspecialchars($f['field_description']) . "\n";
 		echo '</td></tr>';

--- a/modules/system/do_custom_field_aed.php
+++ b/modules/system/do_custom_field_aed.php
@@ -19,6 +19,7 @@ if (!defined('DP_BASE_DIR')) {
 		$field_htmltype = dpGetParam($_POST, "field_htmltype", NULL);
 		$field_datatype = dpGetParam($_POST, "field_datatype", "alpha");
 		$field_extratags = db_escape(dpGetParam($_POST, "field_extratags", NULL));
+		$field_order = dpGetParam($_POST, "field_order", 0);
 
 		$list_select_items = dpGetParam($_POST, "select_items", NULL);
 
@@ -27,11 +28,11 @@ if (!defined('DP_BASE_DIR')) {
 
 		if ($edit_field_id == 0)
 		{
-			$fid = $custom_fields->add($field_name, $field_description, $field_htmltype, $field_datatype, $field_extratags, $msg);
+			$fid = $custom_fields->add($field_name, $field_description, $field_htmltype, $field_datatype, $field_extratags, $msg, $field_order);
 		}
 		else
 		{
-			$fid = $custom_fields->update($edit_field_id, $field_name, $field_description, $field_htmltype, $field_datatype, $field_extratags, $msg);
+			$fid = $custom_fields->update($edit_field_id, $field_name, $field_description, $field_htmltype, $field_datatype, $field_extratags, $msg, $field_order);
 		}
 	
 		// Add or Update a Custom Field


### PR DESCRIPTION
Implemented Custom Fields ordering and data type validation as per TODOs in `classes/CustomFields.class.php`.
1.  **Field Order**:
    *   Added `field_order` property to `CustomField` class.
    *   Updated `CustomFields` class to sort fields by `field_order` ASC.
    *   Updated `CustomFields::add` and `CustomFields::update` to persist `field_order`.
    *   Updated UI in `modules/system/custom_field_addedit.php` to allow editing `field_order`.
    *   Updated UI in `modules/system/custom_field_editor.php` to display `field_order`.
2.  **Field Data Type**:
    *   Added `field_datatype` property to `CustomField` class.
    *   Implemented `validate()` method in `CustomField` to check for numeric values if datatype is 'numeric'.
    *   Updated `CustomFields::store` to call `validate()` and return errors.
    *   Updated UI in `modules/system/custom_field_addedit.php` to allow selecting `field_datatype` (Text or Numeric).
3.  **Refactoring**:
    *   Updated all `CustomField` subclasses constructors to accept and pass the new parameters.
    *   Removed TODO comments.

---
*PR created automatically by Jules for task [17354982179612042157](https://jules.google.com/task/17354982179612042157) started by @davmont*