### PR TITLE
Validate Eventum directory and config file

### DIFF
--- a/modules/eventum/do_eventum_supplvl_add.php
+++ b/modules/eventum/do_eventum_supplvl_add.php
@@ -10,22 +10,28 @@
 	{
 		$ok = true;
 		$evconfig = New CEventumConfig();
-		// TODO: if the directory changes, check that it exists and that a valid config file
-		// exists in that directory.  For the moment just save the value
 		$current_dir = $evconfig->getValue('eventum_directory');
 		$evdir = dPgetParam($_POST, 'eventum_directory', '');
 		if (substr($evdir, -1) == DIRECTORY_SEPARATOR)
-		  $evdir = substr($evdir, 0, -1);
+			$evdir = substr($evdir, 0, -1);
 		if ($evdir && $evdir != $current_dir) {
-		  $evcfile = $evdir . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'config.inc.php';
-		  if ( ! file_exists($evcfile)) {
-		  	// Error!
-			$AppUI->setMsg('Eventum directory invalid, no changes saved', UI_MSG_ALERT);
-			$ok = false;
-		  } else {
-		    $GLOBALS['evDirChanged'] = true;
-		    $GLOBALS['evDir'] = $evdir;
-		  }
+			if (!is_dir($evdir)) {
+				$AppUI->setMsg('Eventum directory invalid (not a directory)', UI_MSG_ALERT);
+				$ok = false;
+			} else {
+				$evcfile = $evdir . DIRECTORY_SEPARATOR . 'config.inc.php';
+				if (!file_exists($evcfile)) {
+					$evcfile = $evdir . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'config.inc.php';
+				}
+
+				if (!file_exists($evcfile) || !is_readable($evcfile)) {
+					$AppUI->setMsg('Eventum config file not found or not readable', UI_MSG_ALERT);
+					$ok = false;
+				} else {
+					$GLOBALS['evDirChanged'] = true;
+					$GLOBALS['evDir'] = $evdir;
+				}
+			}
 		}
 		if ($ok) {
 		  $evconfig->setValue('eventum_directory', dPgetParam($_POST, 'eventum_directory', ''));

--- a/modules/eventum/eventum.class.php
+++ b/modules/eventum/eventum.class.php
@@ -65,9 +65,17 @@ require_once $AppUI->getSystemClass('libmail');
 		function loadEventumConfig()
 		{
 			$evdir = $this->getValue('eventum_directory');
-			$evcfg = $evdir . DIRECTORY_SEPARATOR . 'config.inc.php';
-			if (! $evdir || ! is_readable($evcfg))
+			if (!$evdir) {
 				return false;
+			}
+			$evcfg = $evdir . DIRECTORY_SEPARATOR . 'config.inc.php';
+			if (!is_readable($evcfg)) {
+				$evcfg = $evdir . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'config.inc.php';
+			}
+
+			if (!is_readable($evcfg)) {
+				return false;
+			}
 			$ev = file($evcfg);
 			// Find those records that set defines that we are interested in
 			$defines = preg_grep('/^\s*@?\s*define\s*\([\'"]?APP_/', $ev);


### PR DESCRIPTION
This change adds validation logic to the Eventum module configuration form to ensure the specified directory exists and contains a valid configuration file. It supports both the standard root location and `config/` subdirectory for `config.inc.php`. It also updates the configuration loader to support the `config/` subdirectory, fixing a potential issue where valid configuration might not be loaded.

---
*PR created automatically by Jules for task [14680862833546386008](https://jules.google.com/task/14680862833546386008) started by @davmont*