### PR TITLE
Fix undefined variables in holiday module setup

### DIFF
--- a/modules/holiday/setup.php
+++ b/modules/holiday/setup.php
@@ -57,11 +57,15 @@ class CSetupHoliday {
 		$ok = $ok & $q -> exec();
 		
 		// Set default settings
+		$holiday_manual = 1;
+		$holiday_auto = 0;
+		$holiday_driver = 0;
+
 		$q = new DBQuery();
 		$q -> addTable('holiday_settings');
-		$q -> addInsert('holiday_manual', $holiday_manual+0); // TODO: Check these values, as they don't look right
-		$q -> addInsert('holiday_auto',$holiday_auto+0);
-		$q -> addInsert('holiday_driver',$holiday_driver+0);        	
+		$q -> addInsert('holiday_manual', $holiday_manual);
+		$q -> addInsert('holiday_auto', $holiday_auto);
+		$q -> addInsert('holiday_driver', $holiday_driver);
 		$ok = $ok & $q->exec();
 		if($ok){
 			return null;


### PR DESCRIPTION
This change initializes the `$holiday_manual`, `$holiday_auto`, and `$holiday_driver` variables in `modules/holiday/setup.php` before they are used in the `install()` method. 

Previously, these variables were undefined, relying on implicit casting (`+0`) and causing PHP warnings. The fix sets them to sensible defaults:
- `holiday_manual = 1` (Manual holidays enabled)
- `holiday_auto = 0` (Automatic holidays disabled)
- `holiday_driver = 0` (First available driver)

This ensures a clean installation process without warnings and sets a defined initial state for the module settings. The `TODO` comment flagging this issue has been removed.

---
*PR created automatically by Jules for task [5110778267193896481](https://jules.google.com/task/5110778267193896481) started by @davmont*