### PR TITLE
Fix redirect failures and broken task dependency UI

### DIFF
--- a/classes/ui.class.php
+++ b/classes/ui.class.php
@@ -579,6 +579,8 @@ class CAppUI
 			$params .= (($params) ? '&' : '') . $session_id;
 		}
 		ob_implicit_flush(); // Ensure any buffering is disabled.
+		// Fix for issue #222: URL parameters containing &amp; cause redirect failures
+		$params = str_replace('&amp;', '&', $params);
 		header('Location: index.php?' . $params);
 		exit();	// stop the PHP execution
 	}

--- a/modules/tasks/addedit.php
+++ b/modules/tasks/addedit.php
@@ -257,6 +257,14 @@ var working_days = new Array(<?php echo dPgetConfig('cal_working_days'); ?>);
 var cal_day_start = <?php echo intval(dPgetConfig('cal_day_start')); ?>;
 var cal_day_end = <?php echo intval(dPgetConfig('cal_day_end')); ?>;
 var daily_working_hours = <?php echo intval(dPgetConfig('daily_working_hours')); ?>;
+var projTasksWithEndDates = new Array();
+<?php
+foreach ($projTasksWithEndDates as $key => $val) {
+	if (is_array($val)) {
+		echo "projTasksWithEndDates[$key] = new Array(\"{$val[1]}\", \"{$val[2]}\", \"{$val[3]}\");\n";
+	}
+}
+?>
 function delIt() {
 	if (confirm("<?php echo $AppUI->_('doDelete', UI_OUTPUT_JS).' '.$AppUI->_('Task', UI_OUTPUT_JS).'?';?>")) {
 		document.frmDelete.submit();


### PR DESCRIPTION
This pull request addresses two reported issues:
1.  **Issue #222**: Redirects were failing because URL parameters passed through `dPgetCleanParam` were HTML-encoded (e.g., `&` became `&amp;`), which `header('Location: ...')` does not handle correctly as a query string separator. The fix involves reverting `&amp;` to `&` in `CAppUI::redirect`.
2.  **Issue #212**: The task dependency selection interface was broken because the JavaScript array `projTasksWithEndDates` was not being populated in the view. This array is required by `addedit.js` to calculate start dates based on dependencies. The fix restores the PHP loop to output this array to the client side.

---
*PR created automatically by Jules for task [569647894765079263](https://jules.google.com/task/569647894765079263) started by @davmont*