### PR TITLE
Implement task affiliation in CustomFieldFilelink::store

### DIFF
--- a/classes/CustomFields.class.php
+++ b/classes/CustomFields.class.php
@@ -569,6 +569,12 @@ class CustomFieldFilelink extends CustomField
 			$obj->file_project = $_POST['project_id'];
 		}
 		// todo: implement task affiliation here, too
+		if ($m == 'tasks' && $object_id) {
+			$obj->file_task = $object_id;
+			$task = new CTask();
+			$task->load($object_id);
+			$obj->file_project = $task->task_project;
+		}
 
 		$upload = null;
 		if (isset($_FILES[$this->field_name])) {


### PR DESCRIPTION
Implemented task affiliation logic in `CustomFieldFilelink::store` within `classes/CustomFields.class.php`. This ensures that files uploaded via custom fields on tasks are correctly associated with the task and its project. This addresses the TODO comment found in the code. verified with a reproduction script.

---
*PR created automatically by Jules for task [499677756638611707](https://jules.google.com/task/499677756638611707) started by @davmont*