### PR TITLE
Refactor data access queries to use parameterized IN clauses

### DIFF
--- a/classes/dp.class.php
+++ b/classes/dp.class.php
@@ -378,10 +378,10 @@ class CDpObject {
 		}
 		
 		if (count($allow)) {
-			$this->_query->addWhere($this->_tbl_key . ' IN (' . implode(',', $allow) . ')');
+			$this->_query->addWhere($this->_tbl_key . ' IN (' . implode(',', array_fill(0, count($allow), '?')) . ')', $allow);
 		}
 		if (count($deny)) {
-			$this->_query->addWhere($this->_tbl_key . ' NOT IN (' . implode(',', $deny) . ')');
+			$this->_query->addWhere($this->_tbl_key . ' NOT IN (' . implode(',', array_fill(0, count($deny), '?')) . ')', $deny);
 		}
 		if (isset($extra['where'])) {
 			$this->_query->addWhere($extra['where']);
@@ -455,11 +455,11 @@ class CDpObject {
 		
 		if (count($allow)) {
 			$query->addWhere((($key) ? ($key . '.') : '') . $this->_tbl_key 
-			                 . ' IN (' . implode(',', $allow) . ')');
+			                 . ' IN (' . implode(',', array_fill(0, count($allow), '?')) . ')', $allow);
 		}
 		if (count($deny)) {
 			$query->addWhere((($key) ? ($key . '.') : '') . $this->_tbl_key 
-			                 . ' NOT IN (' . implode(',', $deny) . ')');
+			                 . ' NOT IN (' . implode(',', array_fill(0, count($deny), '?')) . ')', $deny);
  		}
  	}
 

--- a/classes/query.class.php
+++ b/classes/query.class.php
@@ -738,10 +738,17 @@ class DBQuery
 	/**
 	 * loadList - replaces dbLoadList on
 	 */
-	function loadList($maxrows = null, $cache_secs = 0)
+	function loadList($maxrows = null, $cache_secs = 0, $params = array())
 	{
 		global $db;
 		global $AppUI;
+
+		if (!is_array($params)) {
+			$params = array($params);
+		}
+		if (count($params)) {
+			$this->w_params = array_merge($this->w_params, $params);
+		}
 
 		if (!$this->exec(ADODB_FETCH_ASSOC, false, $cache_secs)) {
 			$AppUI->setMsg($db->ErrorMsg(), UI_MSG_ERROR);


### PR DESCRIPTION
Refactor data access queries to use parameterized IN clauses in `CDpObject`.

Changes:
*   Modified `classes/dp.class.php`: Updated `getAllowedRecords` and `setAllowedSQL` to use parameterized `IN` clauses using `array_fill` for placeholders and passing parameter arrays to `addWhere`.
*   Modified `classes/query.class.php`: Updated `loadList` to accept an optional `$params` array, which is merged into the query parameters.

This addresses the requirements to improve security and performance for large result sets. Confirmed that `DBQuery::addWhere` already supports parameter binding.

---
*PR created automatically by Jules for task [2921752652584074337](https://jules.google.com/task/2921752652584074337) started by @davmont*