### PR TITLE
🔒 Fix SQL Injection in HelpDesk item edit

### DIFF
--- a/modules/helpdesk/addedit.php
+++ b/modules/helpdesk/addedit.php
@@ -5,7 +5,7 @@ if (!defined('DP_BASE_DIR')){
 
 global $HELPDESK_CONFIG;
 
-$item_id = dPgetParam($_GET, 'item_id', 0);
+$item_id = (int) dPgetParam($_GET, 'item_id', 0);
 
 $allowedCompanies = arrayMerge( array( 0 => '' ), getAllowedCompanies() );
 
@@ -43,7 +43,7 @@ if ($item_id) {
 	$q = new DBQuery;
 	$q->addQuery('*');
 	$q->addTable('helpdesk_items');
-	$q->addWhere('item_id = \''.$item_id."'");
+	$q->addWhere('item_id = ' . $item_id);
 	$hditem = $q->loadHash();
 	$q->clear();
 }
@@ -202,7 +202,7 @@ $q->clear();
 	$q->addTable('helpdesk_item_watchers','hiw');
 	$q->addJoin('users', 'u', 'hiw.user_id = u.user_id');
 	$q->addJoin('contacts', 'c', 'u.user_contact = c.contact_id');
-	$q->addWhere('item_id = \''.$item_id."'");
+	$q->addWhere('item_id = ' . $item_id);
 	$watchers = $q->loadHashList();
 	$q->clear();
 


### PR DESCRIPTION
This PR addresses a SQL Injection vulnerability in `modules/helpdesk/addedit.php`.

The variable `$item_id` was being directly concatenated into a SQL query string without sufficient sanitization or casting, allowing for potential SQL injection attacks.

The fix involves:
1.  Explicitly casting `$item_id` to an integer using `(int)` when retrieving it from request parameters.
2.  Updating the `DBQuery` construction to use the integer variable directly, removing the now-redundant single quotes, which is cleaner and safer for numeric fields.

Verified the fix using a reproduction script that simulated the vulnerable and fixed states. Existing tests passed.

---
*PR created automatically by Jules for task [13324611204153547344](https://jules.google.com/task/13324611204153547344) started by @davmont*