### PR TITLE
🔒 Fix SQL Injection in Helpdesk Selector Module

### DIFF
--- a/modules/helpdesk/selector.php
+++ b/modules/helpdesk/selector.php
@@ -30,7 +30,7 @@ function selPermWhere( $table, $idfld ) {
 $debug = false;
 $callback = dPgetParam( $_GET, 'callback', 0 );
 $table = dPgetParam( $_GET, 'table', 0 );
-$comp=dPgetParam($_GET, 'comp', 0);
+$comp = (int) dPgetParam($_GET, 'comp', 0);
 
 $ok = $callback & $table;
 
@@ -51,14 +51,14 @@ case 'companies':
 case 'departments':
 // known issue: does not filter out denied companies
 	$title = 'Department';
-	$company_id = dPgetParam( $_GET, 'company_id', 0 );
+	$company_id = (int) dPgetParam( $_GET, 'company_id', 0 );
 	//$ok &= $company_id;  // Is it safe to delete this line ??? [kobudo 13 Feb 2003]
 	//$where = selPermWhere( 'companies', 'company_id' );
 	$where = "dept_company = company_id ";
 	$where .= "\nAND ".selPermWhere( 'departments', 'dept_id' );
 
 	$table .= ", companies, permissions";
-	$hide_company = dPgetParam( $_GET, 'hide_company', 0 );
+	$hide_company = (int) dPgetParam( $_GET, 'hide_company', 0 );
 	if ( $hide_company == 1 ){
 		$select = "dept_id, dept_name";
 	}else{
@@ -77,7 +77,7 @@ case 'forums':
 	$order = 'forum_name';
 	break;
 case 'projects':
-	$project_company = dPgetParam( $_GET, 'project_company', 0 );
+	$project_company = (int) dPgetParam( $_GET, 'project_company', 0 );
 
 	$title = 'Project';
 	$select = 'project_id,project_name';
@@ -87,7 +87,7 @@ case 'projects':
 	$table .= ", permissions";
 	break;
 case 'tasks':
-	$task_project = dPgetParam( $_GET, 'task_project', 0 );
+	$task_project = (int) dPgetParam( $_GET, 'task_project', 0 );
 
 	$title = 'Task';
 	$select = 'task_id,task_name';


### PR DESCRIPTION
This PR fixes a critical SQL injection vulnerability in `modules/helpdesk/selector.php`. User-supplied GET parameters (like `company_id`) were being concatenated directly into SQL WHERE clauses without sanitization. The fix applies strict `(int)` casting to these parameters before use, ensuring that any injected SQL payload is neutralized (converted to an integer) before reaching the database query. This approach is applied to multiple parameters in the file to provide comprehensive protection.

---
*PR created automatically by Jules for task [4816606508976742362](https://jules.google.com/task/4816606508976742362) started by @davmont*