### PR TITLE
🔒 Fix SQL Injection in Project Management

### DIFF
--- a/modules/projects/do_project_aed.php
+++ b/modules/projects/do_project_aed.php
@@ -61,7 +61,7 @@ else {
             $sql= new DBQuery();
             $sql -> addTable('projects');
             $sql -> addQuery('project_name');
-            $sql -> addWhere('project_id="'.$mantis_pid.'"');
+            $sql -> addWhere('project_id=' . (int)$mantis_pid);
             $sql -> exec();
             $mantis_old_pname = $sql -> fetchRow();
             $mantis_old_pname = $mantis_old_pname[0];


### PR DESCRIPTION
🎯 **What:** Fixed a SQL injection vulnerability in `modules/projects/do_project_aed.php`.
⚠️ **Risk:** The `project_id` parameter (derived from `$_POST`) was being directly concatenated into a SQL query without sanitization. This could allow an attacker to inject arbitrary SQL commands.
🛡️ **Solution:** Cast the `project_id` variable to an integer `(int)` before using it in the `addWhere` clause. This ensures only numeric values are processed, neutralizing any malicious string input. Verified that the surrounding code handles the ID as a number.


---
*PR created automatically by Jules for task [10305953604014046187](https://jules.google.com/task/10305953604014046187) started by @davmont*