### PR TITLE
🔒 Fix SQL Injection in Helpdesk Selector

### DIFF
--- a/modules/helpdesk/selector.php
+++ b/modules/helpdesk/selector.php
@@ -30,7 +30,7 @@ function selPermWhere( $table, $idfld ) {
 $debug = false;
 $callback = dPgetParam( $_GET, 'callback', 0 );
 $table = dPgetParam( $_GET, 'table', 0 );
-$comp=dPgetParam($_GET, 'comp', 0);
+$comp = (int) dPgetParam($_GET, 'comp', 0);
 
 $ok = $callback & $table;
 
@@ -51,14 +51,14 @@ case 'companies':
 case 'departments':
 // known issue: does not filter out denied companies
 	$title = 'Department';
-	$company_id = dPgetParam( $_GET, 'company_id', 0 );
+	$company_id = (int) dPgetParam( $_GET, 'company_id', 0 );
 	//$ok &= $company_id;  // Is it safe to delete this line ??? [kobudo 13 Feb 2003]
 	//$where = selPermWhere( 'companies', 'company_id' );
 	$where = "dept_company = company_id ";
 	$where .= "\nAND ".selPermWhere( 'departments', 'dept_id' );
 
 	$table .= ", companies, permissions";
-	$hide_company = dPgetParam( $_GET, 'hide_company', 0 );
+	$hide_company = (int) dPgetParam( $_GET, 'hide_company', 0 );
 	if ( $hide_company == 1 ){
 		$select = "dept_id, dept_name";
 	}else{
@@ -77,7 +77,7 @@ case 'forums':
 	$order = 'forum_name';
 	break;
 case 'projects':
-	$project_company = dPgetParam( $_GET, 'project_company', 0 );
+	$project_company = (int) dPgetParam( $_GET, 'project_company', 0 );
 
 	$title = 'Project';
 	$select = 'project_id,project_name';
@@ -87,7 +87,7 @@ case 'projects':
 	$table .= ", permissions";
 	break;
 case 'tasks':
-	$task_project = dPgetParam( $_GET, 'task_project', 0 );
+	$task_project = (int) dPgetParam( $_GET, 'task_project', 0 );
 
 	$title = 'Task';
 	$select = 'task_id,task_name';

--- a/tests/test_security_selector.php
+++ b/tests/test_security_selector.php
@@ -1,0 +1,75 @@
+<?php
+// Tests for SQL Injection vulnerability in modules/helpdesk/selector.php
+
+// Define DP_BASE_DIR required by selector.php
+if (!defined('DP_BASE_DIR')) {
+    define('DP_BASE_DIR', dirname(__FILE__) . '/../');
+}
+
+// Mock Classes and Functions
+
+class DBQuery {
+    public static $whereClauses = array();
+
+    function addQuery($q) {}
+    function addTable($t) {}
+    function addWhere($w) {
+        self::$whereClauses[] = $w;
+    }
+    function addOrder($o) {}
+    function loadHashList() { return array(); }
+    function loadColumn() { return array(); }
+    function clear() {}
+}
+
+class CAppUI {
+    var $user_id = 1;
+    function _($str) { return $str; }
+}
+
+$AppUI = new CAppUI();
+
+function dPgetParam(&$arr, $name, $def = null) {
+    return isset($arr[$name]) ? $arr[$name] : $def;
+}
+
+function arrayMerge($a, $b) {
+    return is_array($b) ? array_merge($a, $b) : $a;
+}
+
+function db_error() { return ''; }
+
+function getAllowedUsers($comp, $active) { return array(); }
+
+// --- Test Case 1: Projects Injection ---
+
+// Set up vulnerable state
+$_GET['table'] = 'projects';
+$_GET['project_company'] = '1 OR 1=1';
+$_GET['callback'] = 'cb'; // needs to be set
+
+// Clear captured clauses
+DBQuery::$whereClauses = array();
+
+// Include the file to test
+ob_start(); // Buffer output to avoid cluttering test result
+include DP_BASE_DIR . '/modules/helpdesk/selector.php';
+ob_end_clean();
+
+// Analyze Results
+$foundInjection = false;
+foreach (DBQuery::$whereClauses as $clause) {
+    if (strpos($clause, '1 OR 1=1') !== false) {
+        $foundInjection = true;
+        break;
+    }
+}
+
+if ($foundInjection) {
+    echo "VULNERABILITY DETECTED: project_company injection successful.\n";
+    exit(1); // Fail
+} else {
+    echo "SAFE: project_company injection failed.\n";
+    exit(0); // Pass
+}
+?>


### PR DESCRIPTION
Fixed a SQL Injection vulnerability in `modules/helpdesk/selector.php` by casting user-supplied input parameters (`project_company`, `comp`, `company_id`, `task_project`) to integers. Added a regression test script `tests/test_security_selector.php` to verify the fix.

---
*PR created automatically by Jules for task [2267291297065402949](https://jules.google.com/task/2267291297065402949) started by @davmont*