### PR TITLE
🧪 [testing improvement] Add test for DBQuery::addWhere

### DIFF
--- a/tests/test_dbquery.php
+++ b/tests/test_dbquery.php
@@ -1,0 +1,55 @@
+<?php
+
+if (!defined('DP_BASE_DIR')) {
+    define('DP_BASE_DIR', realpath(dirname(__FILE__) . '/../'));
+}
+
+// Mocking required dependencies for DBQuery standalone testing
+function dPgetConfig($arg1, $arg2 = null) { return $arg2; }
+function dprint($file, $line, $level, $msg) {}
+function db_error() {}
+
+require_once DP_BASE_DIR . '/lib/adodb/adodb.inc.php';
+require_once DP_BASE_DIR . '/classes/query.class.php';
+
+require_once DP_BASE_DIR . '/lib/phpgacl/test_suite/phpunit/phpunit.php';
+
+class DBQueryTest extends TestCase {
+    function testAddWhere() {
+        $q = new DBQuery();
+
+        // Initial state
+        $this->assertEquals(null, $q->where);
+        $this->assertEquals(array(), $q->w_params);
+
+        // Single condition, no params
+        $q->addWhere("id = 1");
+        $this->assertEquals(array("id = 1"), $q->where);
+        $this->assertEquals(array(), $q->w_params);
+
+        // Multiple conditions, no params
+        $q->addWhere("status = 'active'");
+        $this->assertEquals(array("id = 1", "status = 'active'"), $q->where);
+        $this->assertEquals(array(), $q->w_params);
+
+        // With single param
+        $q->addWhere("type = ?", 'user');
+        $this->assertEquals(array("id = 1", "status = 'active'", "type = ?"), $q->where);
+        $this->assertEquals(array('user'), $q->w_params);
+
+        // With multiple params
+        $q->addWhere("age > ? AND age < ?", array(18, 65));
+        $this->assertEquals(array("id = 1", "status = 'active'", "type = ?", "age > ? AND age < ?"), $q->where);
+        $this->assertEquals(array('user', 18, 65), $q->w_params);
+
+        // null condition should not be added
+        $q->addWhere(null);
+        $this->assertEquals(array("id = 1", "status = 'active'", "type = ?", "age > ? AND age < ?"), $q->where);
+        $this->assertEquals(array('user', 18, 65), $q->w_params);
+    }
+}
+
+$suite = new TestSuite("DBQueryTest");
+$result = new TextTestResult();
+$suite->run($result);
+$result->report();


### PR DESCRIPTION
🎯 **What:** The testing gap in `classes/query.class.php:351` (`DBQuery::addWhere`) was addressed. The existing test runner mocks `DBQuery`, so a standalone test runner (`tests/test_dbquery.php`) was created specifically for `DBQuery` functionality.

📊 **Coverage:** The following scenarios are now tested:
- Single condition with no parameters
- Multiple conditions with no parameters
- A single parameter (which correctly tests conversion of scalar parameters to an array)
- An array of multiple parameters
- Passing `null` as a condition (which should be skipped without throwing errors)

✨ **Result:** The `DBQuery::addWhere` method behavior is successfully covered, and state changes (appending to `$where` and `$w_params`) are confidently validated, preventing future regressions.

---
*PR created automatically by Jules for task [12095314370831413597](https://jules.google.com/task/12095314370831413597) started by @davmont*