### PR TITLE
🔒 Fix SQL Injection in Helpdesk Logs

### DIFF
--- a/modules/helpdesk/vw_logs.php
+++ b/modules/helpdesk/vw_logs.php
@@ -1,6 +1,6 @@
 <?php /* HELPDESK $Id: vw_logs.php,v 1.9 2011/08/02 06:22:55 hatax Exp $ */
 global $AppUI, $df, $m;
-$item_id = dPgetParam( $_GET, 'item_id', 0 );
+$item_id = (int) dPgetParam( $_GET, 'item_id', 0 );
 
 /* ANDY blocked 'cost code'
 // Lets check cost codes

--- a/test_sqli.php
+++ b/test_sqli.php
@@ -1,0 +1,84 @@
+<?php
+
+define('DP_BASE_DIR', __DIR__);
+define('UI_OUTPUT_JS', 1);
+
+function dPgetParam(&$arr, $name, $def = null) {
+    return isset($arr[$name]) ? $arr[$name] : $def;
+}
+
+function dPshowImage($a, $b, $c, $d) {
+    return "";
+}
+
+function hditemEditable($item) {
+    return true;
+}
+
+class CDate {
+    public function __construct($date) {}
+    public function format($df) { return ""; }
+}
+
+class MockAppUI {
+    public $user_type = 1;
+    public function _($str) { return $str; }
+    public function getPref($str) { return "Y-m-d"; }
+}
+$AppUI = new MockAppUI();
+
+$queries = [];
+class DBQuery {
+    public $query = [];
+    public $table = [];
+    public $join = [];
+    public $where = [];
+    public $order = [];
+
+    public function addQuery($q) { $this->query[] = $q; }
+    public function addTable($t) { $this->table[] = $t; }
+    public function addJoin($a, $b, $c) { $this->join[] = [$a, $b, $c]; }
+    public function addWhere($w) { $this->where[] = $w; }
+    public function addOrder($o) { $this->order[] = $o; }
+
+    public function loadList() {
+        global $queries;
+        $queries[] = $this->where;
+        return [];
+    }
+
+    public function loadHash() {
+        global $queries;
+        $queries[] = $this->where;
+        return ["item_status" => 1, "item_company_id" => 1, "item_created_by" => 1];
+    }
+}
+
+// Simulate malicious input
+$_GET['item_id'] = "1 OR 1=1";
+
+// Capture output to prevent flooding the console
+ob_start();
+include 'modules/helpdesk/vw_logs.php';
+$output = ob_get_clean();
+
+$passed = true;
+foreach ($queries as $i => $where_clauses) {
+    foreach ($where_clauses as $where) {
+        if (strpos($where, 'OR') !== false) {
+            echo "Test failed: SQL injection payload found in query " . ($i+1) . ": $where\n";
+            $passed = false;
+        }
+    }
+}
+
+if ($passed) {
+    echo "Test passed: No SQL injection payload found in queries.\n";
+    foreach ($queries as $i => $where_clauses) {
+        foreach ($where_clauses as $where) {
+             echo "Query " . ($i+1) . " WHERE clause: $where\n";
+        }
+    }
+} else {
+    exit(1);
+}


### PR DESCRIPTION
🎯 **What:** Fixed an SQL injection vulnerability in `modules/helpdesk/vw_logs.php`.
⚠️ **Risk:** If left unfixed, an attacker could manipulate the `item_id` parameter to inject malicious SQL, potentially allowing unauthorized access to the database or exposing sensitive data.
🛡️ **Solution:** The variable `$item_id` is now explicitly cast to an integer using `(int)` right after it's retrieved via `dPgetParam()`. This strips any injected string data and ensures only a safe integer reaches the database query builder, entirely preventing the SQL injection.

---
*PR created automatically by Jules for task [6489553804091731235](https://jules.google.com/task/6489553804091731235) started by @davmont*