### PR TITLE
🔒 Fix SQL Injection in Mantis integration do_project_aed.php

### DIFF
--- a/modules/mantis/core/dotproject/modules/projects/do_project_aed.php
+++ b/modules/mantis/core/dotproject/modules/projects/do_project_aed.php
@@ -60,7 +60,7 @@ else {
 					$sql= new DBQuery();
 					$sql -> addTable('projects');
 					$sql -> addQuery('project_name');
-					$sql -> addWhere('project_id="'.$mantis_pid.'"');
+					$sql -> addWhere('project_id=' . (int)$mantis_pid);
 					$sql -> exec();
 					$mantis_old_pname = $sql -> fetchRow();
 					$mantis_old_pname = $mantis_old_pname[0];


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a SQL injection in `modules/mantis/core/dotproject/modules/projects/do_project_aed.php` where `$mantis_pid` was used unescaped.
⚠️ **Risk:** The potential impact if left unfixed is that a malicious user could execute arbitrary SQL queries against the database via `$_POST['project_id']`.
🛡️ **Solution:** The fix addresses the vulnerability by explicitly casting the user-supplied `$mantis_pid` to an integer `(int)` before passing it to the `addWhere` clause, ensuring that the constructed SQL is safe.

---
*PR created automatically by Jules for task [4008975657084577865](https://jules.google.com/task/4008975657084577865) started by @davmont*