### PR TITLE
🔒 Fix SQL Injection vulnerability in helpdesk item view

### DIFF
--- a/modules/helpdesk/view.php
+++ b/modules/helpdesk/view.php
@@ -38,7 +38,7 @@ $q->addJoin('users','u','u.user_id = hi.item_assigned_to');
 $q->addJoin('contacts','co','u.user_contact = co.contact_id');
 $q->addJoin('projects','p','p.project_id = hi.item_project_id');
 $q->addJoin('companies','c','c.company_id = hi.item_company_id');
-$q->addWhere('item_id = ' . $item_id);
+$q->addWhere('item_id = ' . (int)$item_id);
 
 $hditem = $q->loadHash();
 if (!$hditem ) {
@@ -75,7 +75,7 @@ if (!$hditem ) {
   $q->addTable('helpdesk_item_watchers');
   $q->addJoin('users','','helpdesk_item_watchers.user_id = users.user_id');
   $q->addJoin('contacts','','user_contact = contact_id');
-  $q->addWhere('item_id = ' . $item_id);
+  $q->addWhere('item_id = ' . (int)$item_id);
   $q->addOrder('contact_last_name, contact_first_name');
   $watchers = $q->loadList();
 


### PR DESCRIPTION
🎯 **What:** Fixed an SQL injection vulnerability in `modules/helpdesk/view.php` by sanitizing the `$item_id` parameter before constructing the query.
⚠️ **Risk:** The un-sanitized `$item_id` variable from the query string (e.g. `$_GET['item_id']`) was directly concatenated into the SQL statement, leaving the application open to potential data breaches, unauthorized access, and database manipulation.
🛡️ **Solution:** The variable `$item_id` is now explicitly cast to an integer inline `(int)$item_id` where it is concatenated into `$q->addWhere`, safely mitigating the vulnerability and maintaining existing valid inputs.

---
*PR created automatically by Jules for task [17249368767731453087](https://jules.google.com/task/17249368767731453087) started by @davmont*