### PR TITLE
⚡ Fix N+1 Query for Calendar Birthdays

### DIFF
--- a/modules/calendar/calendar.class.php
+++ b/modules/calendar/calendar.class.php
@@ -455,20 +455,29 @@ class CMonthCalendar
 		$d = intval(mb_substr($day, 6, 2));
 		$y = intval(substr($day, 0, 4));
 
+		static $birthdays_cache = array();
+
 		if ($this->birthdays !== null && $m == $this->birthdays_month) {
 			$rows = isset($this->birthdays[$d]) ? $this->birthdays[$d] : null;
+		} elseif (isset($birthdays_cache[$m])) {
+			$rows = isset($birthdays_cache[$m][$d]) ? $birthdays_cache[$m][$d] : null;
 		} else {
+			$birthdays_cache[$m] = array();
 			$q = new DBQuery;
 			$q->addTable('contacts', 'con');
 			$q->addQuery('contact_birthday, contact_last_name, contact_first_name, contact_id');
-			if (strlen($d) == 1) {
-				$d = '0' . $d;
+			$m_str = str_pad((string)$m, 2, '0', STR_PAD_LEFT);
+			$q->addWhere("contact_birthday LIKE '%-$m_str-%'");
+			$month_rows = $q->loadList();
+			if ($month_rows) {
+				foreach ($month_rows as $row) {
+					$day_val = intval(substr($row['contact_birthday'], -2));
+					$birthdays_cache[$m][$day_val][] = $row;
+				}
 			}
-			if (strlen($m) == 1) {
-				$m = '0' . $m;
-			}
-			$q->addWhere("contact_birthday LIKE '%$m-$d'");
-			$rows = $q->loadList();
+			$q->clear();
+
+			$rows = isset($birthdays_cache[$m][$d]) ? $birthdays_cache[$m][$d] : null;
 		}
 
 		if ($rows) {


### PR DESCRIPTION
💡 **What:** 
Optimized the `_drawBirthdays` function in the `CMonthCalendar` class by caching birthdays by month via a static variable. 

🎯 **Why:** 
The calendar grid preloads birthdays for the primary month but queries individually (N+1) for "padding days" representing adjacent months (e.g. at the beginning or end of the month view). In an extreme case, showing 14 days from other months triggered 14 extra single-day database queries. Week view and day view were also suffering from individual day queries when not falling in the primary loaded month.

📊 **Measured Improvement:** 
Created a benchmarking test simulating a calendar layout spanning 3 different months (14 padding days + 31 current month days). 
- Baseline: 14 individual DB queries for the padding days.
- Optimized: 2 DB queries (one for the entire previous month, one for the entire next month).
This drops the query overhead per calendar render drastically.

---
*PR created automatically by Jules for task [14197025135556303183](https://jules.google.com/task/14197025135556303183) started by @davmont*