### PR TITLE
🧹 Replace Deprecated split() Function in modules/earnings/inv_aed.php

### DIFF
--- a/modules/earnings/inv_aed.php
+++ b/modules/earnings/inv_aed.php
@@ -38,7 +38,7 @@ if (isset( $_POST['inv_dosql'] ) ) {
 		// Remove earning Item(s) From earning
 		$remove_items = "";
 		foreach ($_POST as $item) {
-			list($item_action,$item_value) = split(":",$item);
+			@list($item_action,$item_value) = explode(":",$item);
 			if ( $item_action = "remove" ) {
 				if ( intval($item_value) > 0 ) {
 					if ( strlen($remove_items) > 0 ) {
@@ -89,7 +89,7 @@ if (isset( $_POST['inv_dosql'] ) ) {
 	if ($_POST['inv_dosql'] == "additem") {
 		$add_items = "";
 		foreach ($_POST as $item) {
-			list($item_action,$item_value) = split(":",$item);
+			@list($item_action,$item_value) = explode(":",$item);
 			if ( $item_action = "add" ) {
 				if ( intval($item_value) > 0 ) {
 					if ( strlen($add_items) > 0 ) {


### PR DESCRIPTION
🎯 **What:** Replaced the deprecated `split(":",$item)` function with `explode(":",$item)` in `modules/earnings/inv_aed.php` at lines 41 and 92. Also added error suppression `@` operator to `list()` as a safety measure for iterating over non-delimited strings to prevent warnings in modern PHP.

💡 **Why:** `split()` was deprecated in PHP 5.3 and removed in 7.0. Because the delimiter is a simple string `:`, `explode` is the direct and faster replacement. This improves code health and ensures compatibility with newer PHP versions.

✅ **Verification:** Verified by running the existing test suite using `php tests/cli_runner.php`. The test execution completed successfully without any newly introduced errors or failures. Checked with code review to ensure backward compatibility and no behavioral changes.

✨ **Result:** The code health issue is successfully resolved, providing better compatibility and maintainability for the codebase while keeping its original behavior intact.

---
*PR created automatically by Jules for task [16258761402991004203](https://jules.google.com/task/16258761402991004203) started by @davmont*