### PR TITLE
Deprecate isAllowed function

### DIFF
--- a/includes/permissions.php
+++ b/includes/permissions.php
@@ -53,15 +53,16 @@ function checkFlag($flag, $perm_type, $old_flag)
 	}
 }
 
-// TODO: isAllowed should be depricated as it's old and unused
 /**
  * This function checks certain permissions for
  * a given module and optionally an item_id.
  *
  * $perm_type can be PERM_READ or PERM_EDIT
+ * @deprecated
  */
 function isAllowed($perm_type, $mod, $item_id = 0)
 {
+	trigger_error("isAllowed() has been deprecated and will be removed in a future release.", E_USER_DEPRECATED);
 	$invert = false;
 	switch ($perm_type) {
 		case PERM_READ:


### PR DESCRIPTION
Marked the `isAllowed` function in `includes/permissions.php` as deprecated since it is old and unused.

- Added the `@deprecated` PHPDoc tag to the function's docblock.
- Added a runtime `trigger_error("isAllowed() has been deprecated and will be removed in a future release.", E_USER_DEPRECATED);` at the beginning of the function body.
- Removed the old inline TODO comment.

---
*PR created automatically by Jules for task [11834496398445900457](https://jules.google.com/task/11834496398445900457) started by @davmont*