### PR TITLE
🧹 code health: Remove unused require_once statements in risks module

### DIFF
--- a/modules/risks/indexProjectView.php
+++ b/modules/risks/indexProjectView.php
@@ -4,7 +4,6 @@ if (!defined('DP_BASE_DIR')) {
 }
 
 $AppUI->savePlace();
-//require_once (DP_BASE_DIR . "/modules/risks/translations.php");
 // retrieve any state parameters
 if (isset($_REQUEST['project_id'])) {
     $AppUI->setState('RisksIdxProject', intval($_REQUEST['project_id']));

--- a/modules/risks/index_table.php
+++ b/modules/risks/index_table.php
@@ -5,7 +5,6 @@ $q->addTable('risks');
 $q->addOrder('risk_id');
 $q->setLimit(100);
 $list1 = $q->loadList();
-//require_once (DP_BASE_DIR . "/modules/risks/translations.php");
 foreach ($list1 as $line) {     
     $risk_id = $line['risk_id'];
     $Priority;

--- a/modules/risks/risks.class.php
+++ b/modules/risks/risks.class.php
@@ -3,7 +3,6 @@ if (!defined('DP_BASE_DIR')) {
 	die('You should not access this file directly.');
 }
 
-//require_once $AppUI->getSystemClass('dp');
 require_once($AppUI->getSystemClass('dp'));
 require_once($AppUI->getModuleClass('projects'));
 /**


### PR DESCRIPTION
🎯 **What:** Removed commented out `require_once` statements from `modules/risks/risks.class.php`, `modules/risks/indexProjectView.php`, and `modules/risks/index_table.php`.
💡 **Why:** This improves readability and maintainability by removing unused and confusing commented out code.
✅ **Verification:** Ran `php tests/cli_runner.php` and manually reviewed changes to ensure that no functionality was broken since the lines removed were only commented out statements.
✨ **Result:** A cleaner codebase with less dead code.

---
*PR created automatically by Jules for task [6833542187356937281](https://jules.google.com/task/6833542187356937281) started by @davmont*