### PR TITLE
🔒 Fix SQL Injection in Project AED where clause

### DIFF
--- a/modules/mantis/core/dotproject/modules/projects/do_project_aed.php
+++ b/modules/mantis/core/dotproject/modules/projects/do_project_aed.php
@@ -60,7 +60,7 @@ else {
 					$sql= new DBQuery();
 					$sql -> addTable('projects');
 					$sql -> addQuery('project_name');
-					$sql -> addWhere('project_id="'.$mantis_pid.'"');
+					$sql -> addWhere('project_id=' . (int)$mantis_pid);
 					$sql -> exec();
 					$mantis_old_pname = $sql -> fetchRow();
 					$mantis_old_pname = $mantis_old_pname[0];

--- a/modules/projects/do_project_aed.php
+++ b/modules/projects/do_project_aed.php
@@ -61,7 +61,7 @@ else {
             $sql= new DBQuery();
             $sql -> addTable('projects');
             $sql -> addQuery('project_name');
-            $sql -> addWhere('project_id="'.$mantis_pid.'"');
+            $sql -> addWhere('project_id=' . (int)$mantis_pid);
             $sql -> exec();
             $mantis_old_pname = $sql -> fetchRow();
             $mantis_old_pname = $mantis_old_pname[0];


### PR DESCRIPTION
🎯 **What:** Fixed an SQL injection vulnerability in `modules/projects/do_project_aed.php` within the `project_id` parameter evaluation. Also addressed a duplicated file under `modules/mantis/core/dotproject/modules/projects/do_project_aed.php`.

⚠️ **Risk:** The unescaped variable `$mantis_pid` taken directly from `$_POST['project_id']` was concatenated into the `WHERE` clause. This allows malicious actors to execute arbitrary SQL statements by passing malicious input like `0" OR 1=1; --`. This is an incredibly severe vulnerability.

🛡️ **Solution:** The variable is now forcefully typecasted to an integer `(int)$mantis_pid` before string concatenation, stripping any non-numeric input and avoiding any chance of SQL Injection.

---
*PR created automatically by Jules for task [15110396693641217922](https://jules.google.com/task/15110396693641217922) started by @davmont*