### PR TITLE
🧹 Fix deprecated invoice delete query

### DIFF
--- a/modules/invoices/setup.php
+++ b/modules/invoices/setup.php
@@ -70,8 +70,12 @@ class CSetupInvoices
 		$q->dropTable('invoices');
 		$q->exec();
 		$q->clear();
-		// TODO Fix this delete query
-		//db_exec( "delete from permissions where permission_grant_on like 'invoices'");
+
+		$q->setDelete('permissions');
+		$q->addWhere("permission_grant_on = 'invoices'");
+		$q->exec();
+		$q->clear();
+
 		return null;
 	}
 


### PR DESCRIPTION
🎯 **What:** The raw `db_exec` SQL query in the `remove` method of `modules/invoices/setup.php` has been replaced with the standard `DBQuery` query builder syntax.
💡 **Why:** To address a "TODO" code health issue, improving maintainability, consistency, and database abstraction by moving away from legacy raw SQL queries.
✅ **Verification:** Syntax was validated using `php -l modules/invoices/setup.php`, and the full CLI test suite (`php tests/cli_runner.php`) ran successfully with 0 regressions.
✨ **Result:** A cleaner and safer `setup.php` matching the rest of the application's conventions.

---
*PR created automatically by Jules for task [16927675009835153091](https://jules.google.com/task/16927675009835153091) started by @davmont*