### PR TITLE
🔒 Fix Stored XSS in Helpdesk View

### DIFF
--- a/modules/helpdesk/view.php
+++ b/modules/helpdesk/view.php
@@ -163,36 +163,36 @@ if (!$hditem ) {
 
       <tr>
         <td align="right" nowrap="nowrap"><?php echo $AppUI->_('Title')?>:</td>
-        <td class="hilite" width="100%"><?php echo $hditem["item_title"]?></td>
+        <td class="hilite" width="100%"><?php echo dPformSafe($hditem["item_title"])?></td>
       </tr>
 
       <tr>
         <td align="right" nowrap="nowrap"><?php echo $AppUI->_('Requestor')?>:</td>
         <td class="hilite" width="100%"><?php
           print $hditem["item_requestor_email"] ? 
-            "<a href=\"mailto:".$hditem["item_requestor_email"]."\">".$hditem['item_requestor']."</a>" :
-            $hditem['item_requestor'];?></td>
+            "<a href=\"mailto:".dPformSafe($hditem["item_requestor_email"])."\">".dPformSafe($hditem['item_requestor'])."</a>" :
+            dPformSafe($hditem['item_requestor']);?></td>
       </tr>
 
       <tr>
         <td align="right" nowrap="nowrap"><?php echo $AppUI->_('Requestor Phone')?>:</td>
-        <td class="hilite" width="100%"><?php echo $hditem["item_requestor_phone"]?></td>
+        <td class="hilite" width="100%"><?php echo dPformSafe($hditem["item_requestor_phone"])?></td>
       </tr>
       <tr>
         <td align="right" nowrap="nowrap"><?php echo $AppUI->_('Assigned To')?>:</td>
         <td class="hilite" width="100%"><?php
           print $assigned_email ?
-            "<a href=\"mailto:$assigned_email\">$assigned_to_name</a>" :
-            $assigned_to_name;?></td>
+            "<a href=\"mailto:".dPformSafe($assigned_email)."\">".dPformSafe($assigned_to_name)."</a>" :
+            dPformSafe($assigned_to_name);?></td>
       </tr>
       <tr>
         <td align="right" nowrap="nowrap"><?php echo $AppUI->_('Company')?>:</td>
-        <td class="hilite" width="100%"><?php echo $hditem["company_name"]?></td>
+        <td class="hilite" width="100%"><?php echo dPformSafe($hditem["company_name"])?></td>
       </tr>
 
       <tr>
         <td align="right" nowrap="nowrap"><?php echo $AppUI->_('Project')?>:</td>
-        <td class="hilite" width="100%" style="background-color: #<?php echo $hditem['project_color_identifier']?>;"><a href="./index.php?m=projects&a=view&project_id=<?php echo $hditem["project_id"]?>"; style="color: <?php echo  bestColor( $hditem['project_color_identifier'] ) ?>;"><?php echo $hditem["project_name"]?></a></td>
+        <td class="hilite" width="100%" style="background-color: #<?php echo dPformSafe($hditem['project_color_identifier'])?>;"><a href="./index.php?m=projects&a=view&project_id=<?php echo $hditem["project_id"]?>"; style="color: <?php echo  bestColor( $hditem['project_color_identifier'] ) ?>;"><?php echo dPformSafe($hditem["project_name"])?></a></td>
       </tr>
     </table>
     </td><td valign="top">

--- a/tests/test_helpdesk_view.php
+++ b/tests/test_helpdesk_view.php
@@ -1,0 +1,7 @@
+<?php
+define('DP_BASE_DIR', realpath(dirname(__FILE__) . '/../'));
+require_once DP_BASE_DIR . '/tests/bootstrap.php';
+
+echo dPformSafe('<script>alert("XSS")</script>');
+echo "\n";
+echo "Test executed successfully\n";


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Stored Cross-Site Scripting (XSS) in `modules/helpdesk/view.php` caused by rendering user-controlled data without proper HTML escaping. Specifically, `$hditem['item_title']` and other fields were echoed directly.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could inject malicious JavaScript into helpdesk item fields (like the title or requestor info). When an admin or user views the item, the script would execute in their browser context, potentially leading to session hijacking, unauthorized actions, or data theft.

🛡️ **Solution:** How the fix addresses the vulnerability
All unescaped outputs of user-controlled `$hditem` data in `modules/helpdesk/view.php` have been wrapped in `dPformSafe()`. This is dotProject's standard function for HTML-escaping strings for safe output, mitigating any XSS attack vectors.

---
*PR created automatically by Jules for task [15023023885279786560](https://jules.google.com/task/15023023885279786560) started by @davmont*