### PR TITLE
🧹 Add the administrator ACL access in permissions setup

### DIFF
--- a/db/upgrade_permissions.php
+++ b/db/upgrade_permissions.php
@@ -136,8 +136,7 @@ $perms->add_acl($login_perms, null, array($role), null, null, 1, 1, null, null, 
 
 // Administrator has ALL on ALL
 $perms->add_acl($all_perms, null, array($admin_role), null, array($all_mods), 1, 1, null, null, 'user');
-$perms->add_acl($access_perms, null, array($admin_role), $acl_perms, null, 1, 1, null, null, 'user');
-// TODO:  Add the administrator ACL access.
+$perms->add_acl($all_perms, null, array($admin_role), $acl_perms, null, 1, 1, null, null, 'user');
 
 // Guest has view on ALL
 $perms->add_acl($view_perms, null, array($guest_role), null, array($non_admin_mods), 1, 1, null, null, 'user');


### PR DESCRIPTION
🎯 **What:** The administrator role was only being granted `access` permission over the ACL system (`sys` `acl` module) during setup via `$access_perms`. This commit changes the assignment to `$all_perms` to properly give administrators full access to ACL administration features, and removes the `TODO` comment noting the missing permission setup.
💡 **Why:** To improve code health by cleaning up an outdated TODO while ensuring administrative roles correctly receive elevated permissions to manage ACL settings immediately upon upgrade/initialization.
✅ **Verification:** Verified that `$all_perms` correctly applies the full application permission set to the administrator role (`$admin_role`) for the `$acl_perms` module and passed `cli_runner.php` tests.
✨ **Result:** A cleaner setup script that no longer contains the unimplemented TODO item and gives accurate permissions.

---
*PR created automatically by Jules for task [5440432038207055933](https://jules.google.com/task/5440432038207055933) started by @davmont*