### PR TITLE
Fix access checks for public items in bugspray module

### DIFF
--- a/modules/bugspray/addedit.php
+++ b/modules/bugspray/addedit.php
@@ -18,15 +18,15 @@ db_loadHash( $sql, $hditem );
   $canRead = 0;
   $canEdit = 0;
 
-  //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
+  //Check to make sure that either this user created this record, or it belongs to that user company or it's a public item.
   $canReadCompany = !getDenyRead( "companies", $hditem['item_company_id'] );
-  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || !empty($hditem['item_public'])){
+  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || (int)@$hditem['item_public'] == 1){
   	$canRead = 1;
   }
 
-  //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
+  //Check to make sure that either this user created this record, or it belongs to that user company or it's a public item.
   $canEditCompany = !getDenyEdit( "companies", $hditem['item_company_id'] );
-  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || !empty($hditem['item_public'])){
+  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || (int)@$hditem['item_public'] == 1){
   	$canEdit = 1;
   }
   

--- a/modules/bugspray/view.php
+++ b/modules/bugspray/view.php
@@ -51,15 +51,15 @@ if (!db_loadHash( $sql, $hditem )) {
   $canRead = 0;
   $canEdit = 0;
 
-  //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
+  //Check to make sure that either this user created this record, or it belongs to that user company or it's a public item.
   $canReadCompany = !getDenyRead( "companies", $hditem['item_company_id'] );
-  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || @$hditem['item_public'] == 1){
+  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || (int)@$hditem['item_public'] == 1){
   	$canRead = 1;
   }
 
-  //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
+  //Check to make sure that either this user created this record, or it belongs to that user company or it's a public item.
   $canEditCompany = !getDenyEdit( "companies", $hditem['item_company_id'] );
-  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || !empty($hditem['item_public'])){
+  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || (int)@$hditem['item_public'] == 1){
   	$canEdit = 1;
   }
   


### PR DESCRIPTION
Fix access checks for public items in bugspray module

Standardized read and edit access checks in modules/bugspray/view.php and modules/bugspray/addedit.php to correctly check if an item is public using `(int)@$hditem['item_public'] == 1` instead of `!empty(...)`. This resolves the old TODOs in the codebase while keeping the legacy logic intact and ensuring strict integer comparison.

---
*PR created automatically by Jules for task [15781058060619363658](https://jules.google.com/task/15781058060619363658) started by @davmont*