### PR TITLE
🔒 Fix XSS in barcsim_details.php

### DIFF
--- a/modules/monitoringandcontrol/jpgraph/src/Examples/barcsim_details.php
+++ b/modules/monitoringandcontrol/jpgraph/src/Examples/barcsim_details.php
@@ -4,7 +4,7 @@ if( empty($_GET['id']) ) {
     echo 'Incorrect argument(s) to script <b>'.basename(__FILE__).'</b>.'; 
 }
 else {
-    echo 'Some details on bar with id='.$_GET['id'];
+    echo 'Some details on bar with id='.htmlspecialchars($_GET['id'], ENT_QUOTES);
 }
 
 ?>


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a Cross-Site Scripting (XSS) issue in `modules/monitoringandcontrol/jpgraph/src/Examples/barcsim_details.php` where the `$_GET['id']` parameter was directly echoed without sanitization.
⚠️ **Risk:** The potential impact if left unfixed is that an attacker could inject malicious scripts into the page via the `id` query parameter, which would then be executed in the context of the user's browser.
🛡️ **Solution:** The fix addresses the vulnerability by wrapping the `$_GET['id']` parameter in `htmlspecialchars()` with the `ENT_QUOTES` flag, effectively neutralizing any malicious payload before outputting it to the browser.

---
*PR created automatically by Jules for task [14581016615239137942](https://jules.google.com/task/14581016615239137942) started by @davmont*