### PR TITLE
🔒 Fix XSS in wireit/inputex/examples/echo.php

### DIFF
--- a/modules/timeplanning/js/jsLibraries/wireit/lib/inputex/examples/echo.php
+++ b/modules/timeplanning/js/jsLibraries/wireit/lib/inputex/examples/echo.php
@@ -1,3 +1,3 @@
 <?php
-   echo stripslashes($_POST["value"]);
+   echo htmlspecialchars(stripslashes($_POST["value"]), ENT_QUOTES, 'UTF-8');
 ?>


### PR DESCRIPTION
🎯 **What:** Fixed a Cross-Site Scripting (XSS) vulnerability in `modules/timeplanning/js/jsLibraries/wireit/lib/inputex/examples/echo.php`.

⚠️ **Risk:** An attacker could exploit this vulnerability to execute arbitrary JavaScript in the context of the user's browser, potentially leading to session hijacking, defacement, or other malicious actions if they coerce a user into submitting a crafted form.

🛡️ **Solution:** Wrapped the `stripslashes($_POST["value"])` output with `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` to properly sanitize the output and neutralize any embedded HTML or JavaScript tags. Tested that the change introduces no regressions via `tests/cli_runner.php`.

---
*PR created automatically by Jules for task [12037264790007801417](https://jules.google.com/task/12037264790007801417) started by @davmont*