### PR TITLE
🔒 Fix XSS in jpgraph example scripts

### DIFF
--- a/modules/monitoringandcontrol/jpgraph/src/Examples/barcsim_details.php
+++ b/modules/monitoringandcontrol/jpgraph/src/Examples/barcsim_details.php
@@ -4,7 +4,7 @@ if( empty($_GET['id']) ) {
     echo 'Incorrect argument(s) to script <b>'.basename(__FILE__).'</b>.'; 
 }
 else {
-    echo 'Some details on bar with id='.$_GET['id'];
+    echo 'Some details on bar with id='.htmlspecialchars($_GET['id'], ENT_QUOTES);
 }
 
 ?>

--- a/modules/monitoringandcontrol/jpgraph/src/Examples/csim_in_html_ex1.php
+++ b/modules/monitoringandcontrol/jpgraph/src/Examples/csim_in_html_ex1.php
@@ -26,7 +26,7 @@ if( empty($_GET['clickedon']) ) {
    echo '<b style="color:darkred;">Clicked on bar: &lt;none></b>';
 }
 else {
-   echo '<b style="color:darkred;">Clicked on bar: '.$_GET['clickedon'].'</b>';
+   echo '<b style="color:darkred;">Clicked on bar: '.htmlspecialchars($_GET['clickedon'], ENT_QUOTES).'</b>';
 }
 echo '<p />';
 ?>

--- a/modules/monitoringandcontrol/jpgraph/src/Examples/csim_in_html_ex2.php
+++ b/modules/monitoringandcontrol/jpgraph/src/Examples/csim_in_html_ex2.php
@@ -33,14 +33,14 @@ if( empty($_GET['clickedon']) ) {
    echo '<b style="color:darkred;">Clicked on bar: &lt;none></b>';
 }
 else {
-   echo '<b style="color:darkred;">Clicked on bar: '.$_GET['clickedon'].'</b>';
+   echo '<b style="color:darkred;">Clicked on bar: '.htmlspecialchars($_GET['clickedon'], ENT_QUOTES).'</b>';
 }
 echo '<p />';
 if( empty($_GET['pie_clickedon']) ) {
    echo '<b style="color:darkred;">Clicked on pie slice: &lt;none></b>';
 }
 else {
-   echo '<b style="color:darkred;">Clicked on pie slice: '.$_GET['pie_clickedon'].'</b>';
+   echo '<b style="color:darkred;">Clicked on pie slice: '.htmlspecialchars($_GET['pie_clickedon'], ENT_QUOTES).'</b>';
 }
 echo '<p />';
 ?>


### PR DESCRIPTION
🎯 **What:** The vulnerabilities fixed were reflected Cross-Site Scripting (XSS) in the jpgraph example scripts `csim_in_html_ex1.php`, `csim_in_html_ex2.php`, and `barcsim_details.php`.
⚠️ **Risk:** These files directly outputted user-controlled input (`$_GET['clickedon']`, `$_GET['pie_clickedon']`, and `$_GET['id']`) to the page without any sanitization. If left unfixed, an attacker could potentially execute malicious JavaScript in a victim's browser if the victim followed a crafted link to these example scripts.
🛡️ **Solution:** The fix addresses the vulnerability by wrapping the outputs with `htmlspecialchars(..., ENT_QUOTES)`. This safely encodes HTML entities like `<`, `>`, and quotes to prevent any script execution.

---
*PR created automatically by Jules for task [11932148433654683303](https://jules.google.com/task/11932148433654683303) started by @davmont*