### PR TITLE
🔒 Fix potential SQL injection in risks module index_table.php

### DIFF
--- a/modules/risks/index_table.php
+++ b/modules/risks/index_table.php
@@ -23,8 +23,8 @@ foreach ($list1 as $line) {
         }
     }
     $dbprefix = dPgetConfig('dbprefix', '');
-    $consulta = "UPDATE {$dbprefix}risks SET risk_priority = '$Priority' WHERE risk_id = '$risk_id'";
-    $resultado = mysql_query($consulta) or die($AppUI->_("LBL_QUERY_FAIL"));
+    $consulta = "UPDATE {$dbprefix}risks SET risk_priority = " . (int)$Priority . " WHERE risk_id = " . (int)$risk_id;
+    $resultado = db_exec($consulta) or die($AppUI->_("LBL_QUERY_FAIL"));
 }
 
 $q->clear();


### PR DESCRIPTION
🎯 **What:** Fixed a potential SQL injection vulnerability in `modules/risks/index_table.php`.
⚠️ **Risk:** User inputs or untrusted data within the `risk_id` and potentially `Priority` variables could be used to manipulate the `UPDATE` query, leading to SQL injection which could allow unauthorized modifications to the database records or data exfiltration.
🛡️ **Solution:** Replaced the direct use of the deprecated `mysql_query()` with the application's standard `db_exec()` function. Furthermore, securely cast the `$Priority` and `$risk_id` variables to integers `(int)` before interpolating them into the query. This prevents any arbitrary string input from executing malicious SQL commands and correctly scopes the inputs to numeric types as required by the schema.

---
*PR created automatically by Jules for task [16436780563327728579](https://jules.google.com/task/16436780563327728579) started by @davmont*