### PR TITLE
Fix public item access control checks in bugspray module

### DIFF
--- a/modules/bugspray/addedit.php
+++ b/modules/bugspray/addedit.php
@@ -20,13 +20,13 @@ db_loadHash( $sql, $hditem );
 
   //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
   $canReadCompany = !getDenyRead( "companies", $hditem['item_company_id'] );
-  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || !empty($hditem['item_public'])){
+  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || (int)@$hditem['item_public'] == 1){
   	$canRead = 1;
   }
 
   //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
   $canEditCompany = !getDenyEdit( "companies", $hditem['item_company_id'] );
-  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || !empty($hditem['item_public'])){
+  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || (int)@$hditem['item_public'] == 1){
   	$canEdit = 1;
   }
   

--- a/modules/bugspray/view.php
+++ b/modules/bugspray/view.php
@@ -53,13 +53,13 @@ if (!db_loadHash( $sql, $hditem )) {
 
   //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
   $canReadCompany = !getDenyRead( "companies", $hditem['item_company_id'] );
-  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || @$hditem['item_public'] == 1){
+  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || (int)@$hditem['item_public'] == 1){
   	$canRead = 1;
   }
 
   //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
   $canEditCompany = !getDenyEdit( "companies", $hditem['item_company_id'] );
-  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || !empty($hditem['item_public'])){
+  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || (int)@$hditem['item_public'] == 1){
   	$canEdit = 1;
   }
   


### PR DESCRIPTION
Standardized the logic to properly evaluate if a helpdesk item is public across `modules/bugspray/addedit.php` and `modules/bugspray/view.php`. Replaced inconsistent usages (`!empty()` and simple `==`) with an explicitly casted integer check `(int)@$hditem['item_public'] == 1` for consistent security controls and warning prevention.

---
*PR created automatically by Jules for task [9477916436352070013](https://jules.google.com/task/9477916436352070013) started by @davmont*