### PR TITLE
🔒 fix(timecard): mitigate XSS vulnerability in vw_newlog.php

### DIFF
--- a/modules/timecard/vw_newlog.php
+++ b/modules/timecard/vw_newlog.php
@@ -116,7 +116,7 @@ $task_log_costcodes = array(""); // Let's add a blank default option
 $task_log_costcodes = array_merge($task_log_costcodes, db_loadColumn($sql));
 */
 
-$proj = &new CProject();
+$proj = new CProject();
 $proj->load($obj->task_project);
 $sql = "SELECT billingcode_id, billingcode_name
 FROM billingcode
@@ -281,7 +281,7 @@ function delIt() {
 	else
 	{
 		//***MOD 20050525 pedroa echo "<input type='hidden' name='task_log_creator' value=".$AppUI->user_id."/>";
-		echo "<input type='hidden' name='task_log_creator' value=".$_GET['userid']."/>";
+		echo "<input type='hidden' name='task_log_creator' value=".(int)$_GET['userid']."/>";
 	}
 ?>
  


### PR DESCRIPTION
🎯 **What:** The `modules/timecard/vw_newlog.php` script had an unescaped Cross-Site Scripting (XSS) vulnerability due to directly outputting `$_GET['userid']` inside a hidden input field on line 284. In addition, an obsolete PHP 4 syntax `&new CProject()` caused a fatal error during linting.

⚠️ **Risk:** A malicious user could craft a URL containing a crafted script in the `userid` GET parameter. If another user clicked the link, it could execute arbitrary JavaScript within their session context, leading to session hijacking, defacement, or unauthorized actions performed on their behalf.

🛡️ **Solution:** The `$_GET['userid']` value is now explicitly cast to an integer `(int)$_GET['userid']`. Because an integer can only contain numeric characters, it inherently stops any injection of HTML tags, quotes, or script payloads. The deprecated `&new` syntax was changed to `new` to pass modern PHP syntax checks.

---
*PR created automatically by Jules for task [8713909139297894869](https://jules.google.com/task/8713909139297894869) started by @davmont*