### PR TITLE
🔒 Fix XSS in JpGraph example scripts

### DIFF
--- a/modules/monitoringandcontrol/jpgraph/src/Examples/csim_in_html_ex1.php
+++ b/modules/monitoringandcontrol/jpgraph/src/Examples/csim_in_html_ex1.php
@@ -26,7 +26,7 @@ if( empty($_GET['clickedon']) ) {
    echo '<b style="color:darkred;">Clicked on bar: &lt;none></b>';
 }
 else {
-   echo '<b style="color:darkred;">Clicked on bar: '.$_GET['clickedon'].'</b>';
+   echo '<b style="color:darkred;">Clicked on bar: '.htmlspecialchars($_GET['clickedon'], ENT_QUOTES).'</b>';
 }
 echo '<p />';
 ?>

--- a/modules/monitoringandcontrol/jpgraph/src/Examples/csim_in_html_ex2.php
+++ b/modules/monitoringandcontrol/jpgraph/src/Examples/csim_in_html_ex2.php
@@ -33,14 +33,14 @@ if( empty($_GET['clickedon']) ) {
    echo '<b style="color:darkred;">Clicked on bar: &lt;none></b>';
 }
 else {
-   echo '<b style="color:darkred;">Clicked on bar: '.$_GET['clickedon'].'</b>';
+   echo '<b style="color:darkred;">Clicked on bar: '.htmlspecialchars($_GET['clickedon'], ENT_QUOTES).'</b>';
 }
 echo '<p />';
 if( empty($_GET['pie_clickedon']) ) {
    echo '<b style="color:darkred;">Clicked on pie slice: &lt;none></b>';
 }
 else {
-   echo '<b style="color:darkred;">Clicked on pie slice: '.$_GET['pie_clickedon'].'</b>';
+   echo '<b style="color:darkred;">Clicked on pie slice: '.htmlspecialchars($_GET['pie_clickedon'], ENT_QUOTES).'</b>';
 }
 echo '<p />';
 ?>

--- a/modules/monitoringandcontrol/jpgraph/src/Examples/show-example.php
+++ b/modules/monitoringandcontrol/jpgraph/src/Examples/show-example.php
@@ -2,7 +2,7 @@
 <!doctype html public "-//W3C//DTD HTML 4.0 Frameset//EN">
 <html>
 <head>
-<title> Test suite for JpGraph - <?php echo $target; ?></title>
+<title> Test suite for JpGraph - <?php echo htmlspecialchars($target, ENT_QUOTES); ?></title>
 <script type="text/javascript" language="javascript">
 <!--
 function resize()
@@ -15,10 +15,10 @@ function resize()
 <frameset rows="*,*" onLoad="resize()">
 	<?php 
 	if( !strstr($target,"csim") )
-		echo "<frame src=\"show-image.php?target=".basename($target)."\" name=\"image\">";
+		echo "<frame src=\"show-image.php?target=".htmlspecialchars(basename($target), ENT_QUOTES)."\" name=\"image\">";
 	else
-		echo	"<frame src=\"".basename($target)."\" name=\"image\">";
+		echo	"<frame src=\"".htmlspecialchars(basename($target), ENT_QUOTES)."\" name=\"image\">";
 	?>
-	<frame src="show-source.php?target=<?php echo basename($target); ?>" name="source">
+	<frame src="show-source.php?target=<?php echo htmlspecialchars(basename($target), ENT_QUOTES); ?>" name="source">
 </frameset>
 </html>

--- a/modules/monitoringandcontrol/jpgraph/src/Examples/show-image.php
+++ b/modules/monitoringandcontrol/jpgraph/src/Examples/show-image.php
@@ -2,9 +2,9 @@
 <!doctype html public "-//W3C//DTD HTML 4.0 Transitional//EN">
 <html>
 <head>
-<title> Image <?php echo basename($target); ?></title>
+<title> Image <?php echo htmlspecialchars(basename($target), ENT_QUOTES); ?></title>
 </head>
 <body>
-<img src="<?php echo basename($target); ?>" border=0 alt="<?php echo basename($target); ?>" align="left">
+<img src="<?php echo htmlspecialchars(basename($target), ENT_QUOTES); ?>" border=0 alt="<?php echo htmlspecialchars(basename($target), ENT_QUOTES); ?>" align="left">
 </body>
 </html>


### PR DESCRIPTION
🎯 **What:** The JpGraph example scripts (`csim_in_html_ex2.php`, `csim_in_html_ex1.php`, `show-example.php`, `show-image.php`) were echoing unescaped user-controlled inputs from `$_GET` into the HTML output.
⚠️ **Risk:** An attacker could exploit this by crafting malicious URLs containing JavaScript, leading to Cross-Site Scripting (XSS). If an administrator or user visited the malicious link, the attacker could execute arbitrary scripts in the context of the user's session, potentially leading to session hijacking or unauthorized actions.
🛡️ **Solution:** The unescaped variables were wrapped in `htmlspecialchars($var, ENT_QUOTES)`. This safely encodes HTML special characters, neutralizing any potentially injected script tags or event handlers, and rendering the input as harmless text.

---
*PR created automatically by Jules for task [15078543255916697801](https://jules.google.com/task/15078543255916697801) started by @davmont*