### PR TITLE
Remove obsolete `_ADODB_COUNT` replacement in adodb.inc.php

### DIFF
--- a/lib/adodb/adodb.inc.php
+++ b/lib/adodb/adodb.inc.php
@@ -1594,15 +1594,6 @@ if (!defined('_ADODB_LAYER')) {
 	}
 
 	function _Execute($sql,$inputarr=false) {
-		// ExecuteCursor() may send non-string queries (such as arrays),
-		// so we need to ignore those.
-		if( is_string($sql) ) {
-			// Strips keyword used to help generate SELECT COUNT(*) queries
-			// from SQL if it exists.
-			// TODO: obsoleted by #715 - kept for backwards-compatibility
-			$sql = str_replace( '_ADODB_COUNT', '', $sql );
-		}
-
 		if ($this->debug) {
 			global $ADODB_INCLUDED_LIB;
 			if (empty($ADODB_INCLUDED_LIB)) {


### PR DESCRIPTION
Remove obsolete `_ADODB_COUNT` replacement in adodb.inc.php

This code was marked as obsolete by #715 and kept only for
backwards-compatibility. It can be safely removed.

---
*PR created automatically by Jules for task [17666372645648908419](https://jules.google.com/task/17666372645648908419) started by @davmont*