### PR TITLE
🔒 Fix insecure variable extraction (register_globals simulation) in xmlrpc parse_args.php

### DIFF
--- a/modules/tracIntegration/xmlrpc/test/parse_args.php
+++ b/modules/tracIntegration/xmlrpc/test/parse_args.php
@@ -26,6 +26,7 @@
 	}
 
 	// check for command line vs web page input params
+	$allowed_args = array('DEBUG', 'LOCALSERVER', 'URI', 'HTTPSSERVER', 'HTTPSURI', 'PROXY', 'only');
 	if(!isset($_SERVER['REQUEST_METHOD']))
 	{
 		if(isset($argv))
@@ -33,9 +34,9 @@
 			foreach($argv as $param)
 			{
 				$param = explode('=', $param);
-				if(count($param) > 1)
+				if(count($param) > 1 && in_array($param[0], $allowed_args))
 				{
-					$$param[0]=$param[1];
+					${$param[0]}=$param[1];
 				}
 			}
 		}
@@ -44,8 +45,14 @@
 	{
 		// play nice to 'safe' PHP installations with register globals OFF
 		// NB: we might as well consider using $_GET stuff later on...
-		extract($_GET);
-		extract($_POST);
+		foreach ($allowed_args as $arg) {
+			if (isset($_GET[$arg])) {
+				${$arg} = $_GET[$arg];
+			}
+			if (isset($_POST[$arg])) {
+				${$arg} = $_POST[$arg];
+			}
+		}
 	}
 
 	if(!isset($DEBUG))


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The script `modules/tracIntegration/xmlrpc/test/parse_args.php` insecurely utilized `extract($_GET)` and `extract($_POST)`, as well as a dynamic `$$param[0]=$param[1];` assignment loop for command line arguments. This allowed any user-supplied parameter to be registered as a local PHP variable in the script's scope, replicating the dangerous `register_globals` functionality.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could inject arbitrary variable names into the script's execution context. Because this script is included in other components (like `testsuite.php` and `benchmark.php`), attackers could overwrite vital configuration variables, authentication flags, or file paths, potentially leading to unauthorized behavior, data leakage, or further exploitation (like Remote Code Execution if a sensitive path variable is overwritten).

🛡️ **Solution:** How the fix addresses the vulnerability
The `extract()` function and dynamic variable assignments have been replaced with a strict whitelist. A new `$allowed_args` array defines the only valid parameters the script should accept (`DEBUG`, `LOCALSERVER`, `URI`, `HTTPSSERVER`, `HTTPSURI`, `PROXY`, and `only`). 
The logic now iterates over this whitelist, explicitly mapping these specific parameters from `$_POST`, `$_GET`, or `$argv` into local variables, completely nullifying the arbitrary variable injection vulnerability while maintaining the script's intended behavior.

---
*PR created automatically by Jules for task [10801781741859531284](https://jules.google.com/task/10801781741859531284) started by @davmont*