### PR TITLE
Fix bugspray public item access logic

### DIFF
--- a/modules/bugspray/addedit.php
+++ b/modules/bugspray/addedit.php
@@ -18,15 +18,15 @@ db_loadHash( $sql, $hditem );
   $canRead = 0;
   $canEdit = 0;
 
-  //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
+  //Check to make sure that either this user created this record, or it belongs to that user company, or it's a public item.
   $canReadCompany = !getDenyRead( "companies", $hditem['item_company_id'] );
-  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || !empty($hditem['item_public'])){
+  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || (int)@$hditem['item_public'] == 1){
   	$canRead = 1;
   }
 
-  //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
+  //Check to make sure that either this user created this record, or it belongs to that user company, or it's a public item.
   $canEditCompany = !getDenyEdit( "companies", $hditem['item_company_id'] );
-  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || !empty($hditem['item_public'])){
+  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || (int)@$hditem['item_public'] == 1){
   	$canEdit = 1;
   }
   

--- a/modules/bugspray/view.php
+++ b/modules/bugspray/view.php
@@ -51,15 +51,15 @@ if (!db_loadHash( $sql, $hditem )) {
   $canRead = 0;
   $canEdit = 0;
 
-  //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
+  //Check to make sure that either this user created this record, or it belongs to that user company, or it's a public item.
   $canReadCompany = !getDenyRead( "companies", $hditem['item_company_id'] );
-  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || @$hditem['item_public'] == 1){
+  if($canReadCompany || $hditem['item_created_by']==$AppUI->user_id || (int)@$hditem['item_public'] == 1){
   	$canRead = 1;
   }
 
-  //Check to make sure that either this user created this record, or it belongs to that user company TODO:or it's a public item.
+  //Check to make sure that either this user created this record, or it belongs to that user company, or it's a public item.
   $canEditCompany = !getDenyEdit( "companies", $hditem['item_company_id'] );
-  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || !empty($hditem['item_public'])){
+  if($canEditCompany || $hditem['item_created_by']==$AppUI->user_id || !$item_id || (int)@$hditem['item_public'] == 1){
   	$canEdit = 1;
   }
   


### PR DESCRIPTION
This commit addresses the issue generated from legacy `TODO`s in the `bugspray` module. It updates both `addedit.php` and `view.php` to strictly cast and evaluate the `item_public` attribute uniformly across read and edit permission checks.

---
*PR created automatically by Jules for task [4550887232829523186](https://jules.google.com/task/4550887232829523186) started by @davmont*