### PR TITLE
🔒 fix: SQL injection in communication module index_table

### DIFF
--- a/modules/communication/index_table.php
+++ b/modules/communication/index_table.php
@@ -7,7 +7,7 @@ $q->addJoin('communication_channel', 'ch', 'ch.communication_channel_id=c.commun
 $q->addJoin('communication_frequency', 'fr', 'fr.communication_frequency_id=c.communication_frequency_id');
 $q->addJoin('projects', 'p', 'p.project_id=c.communication_project_id');
 if(isset($_POST['project_id']) && $_POST['project_id'] != '0'){    
-    $q->addwhere('c.communication_project_id='.$_POST['project_id']);
+    $q->addwhere('c.communication_project_id=' . (int)$_POST['project_id']);
     $list = $q->loadList();
 }else{
     $q->setLimit(100);


### PR DESCRIPTION
🎯 **What:** Fixed a potential SQL Injection vulnerability in `modules/communication/index_table.php`.
⚠️ **Risk:** The `$_POST['project_id']` parameter was being concatenated directly into a SQL `WHERE` clause without sanitization or casting, allowing an attacker to inject arbitrary SQL commands.
🛡️ **Solution:** The user input `$_POST['project_id']` is now explicitly cast to an integer using `(int)$_POST['project_id']` before being concatenated into the query string, which ensures only numeric values are passed and mitigates the SQL injection risk entirely.

---
*PR created automatically by Jules for task [9072856639828349742](https://jules.google.com/task/9072856639828349742) started by @davmont*