### PR TITLE
🔒 Fix SQL injection vulnerability in timesheet dosql.php

### DIFF
--- a/modules/timesheet/dosql.php
+++ b/modules/timesheet/dosql.php
@@ -16,7 +16,7 @@ if ($punchIn) {
 	$timesheet = new Timesheet();
 	$q->addTable('timesheet');
 	$q->addQuery('*');
-	$q->addWhere("user_id = $AppUI->user_id and timesheet_date = '" . $_POST['timesheet_date'] . "'");
+	$q->addWhere("user_id = " . (int)$AppUI->user_id . " and timesheet_date = '" . db_escape($_POST['timesheet_date']) . "'");
 
 	if (!$q->loadObject($timesheet)) { // timesheet doesn't exist yet.  Create it.
 		$timesheet->timesheet_id = "";
@@ -41,7 +41,7 @@ if ($punchIn) {
 	$timesheet = new Timesheet();
 	$q->addTable('timesheet');
 	$q->addQuery('*');
-	$q->addWhere("user_id = $AppUI->user_id and timesheet_date = '" . $_POST['timesheet_date'] . "'");
+	$q->addWhere("user_id = " . (int)$AppUI->user_id . " and timesheet_date = '" . db_escape($_POST['timesheet_date']) . "'");
 
 	if (!$q->loadObject($timesheet)) { // timesheet doesn't exist yet.  Create it.
 		$timesheet->timesheet_id = "";
@@ -66,7 +66,7 @@ if ($punchIn) {
 	$timesheet = new Timesheet();
 	$q->addTable('timesheet');
 	$q->addQuery('*');
-	$q->addWhere("user_id = $AppUI->user_id and timesheet_date = '" . $_POST['timesheet_date'] . "'");
+	$q->addWhere("user_id = " . (int)$AppUI->user_id . " and timesheet_date = '" . db_escape($_POST['timesheet_date']) . "'");
 
 	if (!$q->loadObject($timesheet)) { // timesheet doesn't exist yet.  Create it.
 		$timesheet->timesheet_id = "";


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
In `modules/timesheet/dosql.php`, there were three instances where raw POST data (`$_POST['timesheet_date']`) and unescaped session data (`$AppUI->user_id`) were directly concatenated into a SQL `WHERE` clause via the `DBQuery::addWhere` method.

⚠️ **Risk:** The potential impact if left unfixed
A malicious user could potentially inject arbitrary SQL commands by manipulating the `timesheet_date` POST parameter or their session `user_id`. This could lead to unauthorized data access, modification, or potential database compromise.

🛡️ **Solution:** How the fix addresses the vulnerability
To fix this, the `user_id` variable was explicitly cast to an integer using `(int)` before concatenation, and the `timesheet_date` variable was sanitized using the application's `db_escape()` function. This prevents any malicious SQL input from altering the intended query logic, while retaining functionality.

---
*PR created automatically by Jules for task [145144770405447569](https://jules.google.com/task/145144770405447569) started by @davmont*