### PR TITLE
🔒 Fix SQL Injection vulnerability in earnings module company_id query

### DIFF
--- a/modules/earnings/inv_aed.php
+++ b/modules/earnings/inv_aed.php
@@ -172,7 +172,7 @@ if (isset( $_POST['inv_dosql'] ) ) {
 		if ( strcmp($_POST["earning_submit_address1"], "") == 0 ) {
 			// The earning address override hasn't been used so let's fill it in automatically
 			// Gather Company Details
-			$sql2="SELECT companies.* FROM companies WHERE company_id='" . $_POST["earning_submit_company_id"] . "';";
+			$sql2="SELECT companies.* FROM companies WHERE company_id='" . (int)$_POST["earning_submit_company_id"] . "';";
 			$crc= db_exec( $sql2 );
 			echo db_error();
 			while ($row = db_fetch_assoc($crc)) {
@@ -223,7 +223,7 @@ if (isset( $_POST['inv_dosql'] ) ) {
 		if ( strcmp($_POST["earning_submit_address1"], "") == 0 ) {
 			// The earning address override hasn't been used so let's fill it in automatically
 			// Gather Company Details
-			$sql2="SELECT companies.* FROM companies WHERE company_id='" . $_POST["earning_submit_company_id"] . "';";
+			$sql2="SELECT companies.* FROM companies WHERE company_id='" . (int)$_POST["earning_submit_company_id"] . "';";
 			$crc= db_exec( $sql2 );
 			echo db_error();
 			while ($row = db_fetch_assoc($crc)) {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a SQL injection in `modules/earnings/inv_aed.php`.
⚠️ **Risk:** The potential impact if left unfixed is that a malicious user could inject arbitrary SQL code into the `company_id` parameter to manipulate the database query, potentially leading to data exfiltration, unauthorized modification, or denial of service.
🛡️ **Solution:** The fix addresses the vulnerability by type-casting `$_POST["earning_submit_company_id"]` to an integer (`(int)`) when it is being used in the SQL query string. Since `company_id` is a numeric ID, this completely nullifies any malicious SQL payloads (which would be evaluated as `0`) while allowing legitimate integers to pass through.

---
*PR created automatically by Jules for task [12663062810316423871](https://jules.google.com/task/12663062810316423871) started by @davmont*