### PR TITLE
🔒 Fix SQL injection in vw_calendar_by_user.php and vw_timecard.php

### DIFF
--- a/modules/timecard/vw_calendar_by_user.php
+++ b/modules/timecard/vw_calendar_by_user.php
@@ -16,9 +16,9 @@ $end_date = intval( $log_end_date ) ? new CDate( $log_end_date ) : new CDate();
 
 $df = $AppUI->getPref('SHDATEFORMAT');
 if (isset( $_GET['user_id'] )) {
-	$sql = "SELECT user_contact FROM users WHERE user_id = ".$_GET['user_id'] ;
+	$sql = "SELECT user_contact FROM users WHERE user_id = ".(int)$_GET['user_id'] ;
   $user_contact = db_loadresult( $sql );
-	$sql = "SELECT contact_company FROM contacts WHERE contact_id = ".$user_contact ;
+	$sql = "SELECT contact_company FROM contacts WHERE contact_id = ".(int)$user_contact ;
 	//print "<pre>$sql</pre>";
 
 	$company_id = db_loadResult( $sql );
@@ -194,11 +194,11 @@ if ($do_report) {
 <?php
 	if ($log_pdf) {
 	// make the PDF file
-		$sql = "SELECT user_contact FROM users WHERE user_id = ".$user_id ;
+		$sql = "SELECT user_contact FROM users WHERE user_id = ".(int)$user_id ;
     $user_contact = db_loadresult( $sql );
-	  $sql = "SELECT contacts.contact_first_name FROM contacts WHERE contact_id = ".$user_contact ;
+	  $sql = "SELECT contacts.contact_first_name FROM contacts WHERE contact_id = ".(int)$user_contact ;
     $firstName = db_loadresult( $sql );
-	  $sql = "SELECT contacts.contact_last_name FROM contacts WHERE contact_id = ".$user_contact ;
+	  $sql = "SELECT contacts.contact_last_name FROM contacts WHERE contact_id = ".(int)$user_contact ;
     $lastName = db_loadresult( $sql );
 		$pname = "For user: ".$firstName." ".$lastName;
 

--- a/modules/timecard/vw_timecard.php
+++ b/modules/timecard/vw_timecard.php
@@ -28,9 +28,9 @@
 	if (isset( $_GET['user_id'] )) {
 	//if (isset( $AppUI->user_id )) {
 	
-		$sql = "SELECT user_contact FROM users WHERE user_id = ".$_GET['user_id'];
+		$sql = "SELECT user_contact FROM users WHERE user_id = ".(int)$_GET['user_id'];
 		$contact_id = db_loadResult( $sql );
-		$sql = "SELECT contact_company FROM contacts WHERE contact_id = ".$contact_id;
+		$sql = "SELECT contact_company FROM contacts WHERE contact_id = ".(int)$contact_id;
 		//print $sql;
 		$company_id = db_loadResult( $sql );
 		//print $company_id.":".getDenyRead( "companies", $company_id );


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a SQL injection flaw where un-sanitized `$_GET['user_id']` and subsequently fetched IDs were passed directly into raw SQL queries within `modules/timecard/vw_calendar_by_user.php` and `modules/timecard/vw_timecard.php`.

⚠️ **Risk:** If left unfixed, attackers could inject arbitrary SQL to modify queries, potentially allowing data exfiltration of sensitive information across the entire database or arbitrarily modifying data.

🛡️ **Solution:** The solution casts `$_GET['user_id']`, `$user_contact`, and `$contact_id` to explicitly be integers (`(int)`) when concatenated into SQL statements. This neutralizes any malicious SQL payloads by ensuring only numeric values are used, resolving the SQL injection vulnerability safely without altering expected numeric functionality.

---
*PR created automatically by Jules for task [10021501507023202313](https://jules.google.com/task/10021501507023202313) started by @davmont*