### PR TITLE
🔒 Fix SQL Injection in MileageLog Module

### DIFF
--- a/modules/mileagelog/vw_mileagelog.php
+++ b/modules/mileagelog/vw_mileagelog.php
@@ -17,14 +17,14 @@
 	$tf = $AppUI->getPref('TIMEFORMAT');
 
 	if (isset( $_GET['user_id'] )) {
-		$sql = "SELECT user_company FROM users WHERE user_id = ".$_GET['user_id'] ;
+		$sql = "SELECT user_company FROM users WHERE user_id = " . (int)$_GET['user_id'];
 		$company_id = db_loadResult( $sql );
 		if(getDenyRead( "companies", $company_id )){
 			$AppUI->redirect( "m=public&a=access_denied" );
 		}
-		$AppUI->setState( 'MileageLogSelectedUser', $_GET['user_id'] );
+		$AppUI->setState( 'MileageLogSelectedUser', (int)$_GET['user_id'] );
 	}
-	$user_id = $AppUI->getState( 'MileageLogSelectedUser' ) ? $AppUI->getState( 'MileageLogSelectedUser' ) : $AppUI->user_id;
+	$user_id = $AppUI->getState( 'MileageLogSelectedUser' ) ? (int)$AppUI->getState( 'MileageLogSelectedUser' ) : $AppUI->user_id;
 
 	if (isset( $_GET['interval'] )) {
 		$AppUI->setState( 'MileageLogInterval', $_GET['interval'] );


### PR DESCRIPTION
🎯 **What:** Fixed a SQL injection vulnerability in `modules/mileagelog/vw_mileagelog.php`.
⚠️ **Risk:** The `user_id` parameter from `$_GET` was being concatenated directly into a SQL query, allowing an attacker to inject arbitrary SQL commands.
🛡️ **Solution:** The user input `$_GET['user_id']` is now explicitly cast to `(int)` before being appended to the SQL string. It is also cast to an integer when saved to and retrieved from the application state via `$AppUI->setState()` and `$AppUI->getState()`, ensuring defense-in-depth against malicious payloads.

---
*PR created automatically by Jules for task [228311669018283262](https://jules.google.com/task/228311669018283262) started by @davmont*