### PR TITLE
🔒 Fix SQL injection vulnerabilities in messages module

### DIFF
--- a/modules/messages/compose_message.php
+++ b/modules/messages/compose_message.php
@@ -17,7 +17,7 @@
 	$q = new DBQuery();
 	$q -> addTable('users');
 	$q -> addQuery('user_signature');
-	$q -> addWhere("user_id = '".$AppUI->user_id."'");
+	$q -> addWhere("user_id = '" . (int)$AppUI->user_id . "'");
 	$signature = $q -> loadResult();
 	
 	if($signature != ""){

--- a/modules/messages/index.php
+++ b/modules/messages/index.php
@@ -60,13 +60,13 @@
 		if(is_null($error_message)){
 			$q = new DBQuery();
 			$q -> setDelete('user_tasks');
-			$q -> addWhere("task_id ='$new_message->task_id'");	
+			$q -> addWhere("task_id ='" . (int)$new_message->task_id . "'");
 			$q -> exec();			
 			
 			$q -> clear();
 			$q -> addTable('user_tasks');
-			$q -> addInsert('task_id', $new_message->task_id);
-			$q -> addInsert('user_id', $_POST["recipient_user_id"]);
+			$q -> addInsert('task_id', (int)$new_message->task_id);
+			$q -> addInsert('user_id', (int)$_POST["recipient_user_id"]);
 			$q -> exec();			
 			
 			$q -> clear();
@@ -74,7 +74,7 @@
 			$q -> addTable('users','u');
 			$q -> addQuery('c.contact_email');
 			$q -> addWhere('u.user_contact = c.contact_id');
-			$q -> addWhere("u.user_id = '".$_POST["recipient_user_id"]."'");
+			$q -> addWhere("u.user_id = '" . (int)$_POST["recipient_user_id"] . "'");
 			$recipient_email = $q -> loadResult();
 			
 			if(dPgetParam($_POST, "send_email", "") != "" && $recipient_email != ""){
@@ -116,8 +116,8 @@
 		$q = new DBQuery();
 		$q -> addTable('user_tasks');
 		$q -> addQuery('count(user_id)');
-		$q -> addWhere("task_id = '".$view_message->task_id."'");
-		$q -> addWhere("user_id = '".$AppUI->user_id."'");
+		$q -> addWhere("task_id = '" . (int)$view_message->task_id . "'");
+		$q -> addWhere("user_id = '" . (int)$AppUI->user_id . "'");
 		
 		$user_present_in_recipients = $q -> loadResult();
 	
@@ -156,7 +156,7 @@
 					break;
 				case "convert_to_task":
 					if($user_present_in_recipients){
-						$view_message->task_project = $_POST["project_id"];
+						$view_message->task_project = (int)$_POST["project_id"];
 						$view_message->task_status  = '0';
 					}
 					break;
@@ -183,12 +183,12 @@
 		$q = new DBQuery();
 		$q -> addTable('user_tasks');
 		$q -> addQuery('count(user_id)');
-		$q -> addWhere("task_id = '".$_GET["reply_to_message_id"]."'");
-		$q -> addWhere("user_id = '".$AppUI->user_id."'");		
+		$q -> addWhere("task_id = '" . (int)$_GET["reply_to_message_id"] . "'");
+		$q -> addWhere("user_id = '" . (int)$AppUI->user_id . "'");
 		$user_present_in_recipients = $q -> loadResult();
 		if($user_present_in_recipients){
 			$message_tab = COMPOSE_MESSAGE_TAB;
-			$reply_to_message_id = $_GET["reply_to_message_id"];
+			$reply_to_message_id = (int)$_GET["reply_to_message_id"];
 		}
 	}
 	

--- a/modules/messages/vw_messages.php
+++ b/modules/messages/vw_messages.php
@@ -11,11 +11,11 @@
 		$q -> addWhere("t.task_status = '-1'");
 	}
 	else if ($show_sent_messages){
-		$q -> addWhere("t.task_owner = '".$AppUI->user_id."'");	
+		$q -> addWhere("t.task_owner = '" . (int)$AppUI->user_id . "'");
 	}
 	else{
 		$q -> addWhere("t.task_status = '0'");
-		$q -> addWhere("ut.user_id     = '".$AppUI->user_id."' ");
+		$q -> addWhere("ut.user_id     = '" . (int)$AppUI->user_id . "' ");
 	}
 	$q -> addOrder('task_priority, task_start_date');
 	
@@ -79,10 +79,10 @@
 					$q = new DBQuery();
 					$q -> addTable('user_tasks');
 					$q -> addQuery('user_id');
-					$q -> addWhere("task_id = '".$view_message->task_id."'");
+					$q -> addWhere("task_id = '" . (int)$view_message->task_id . "'");
 					
 					$recipient_list = "";
-					foreach(db_loadColumn($sql) as $user_id){
+					foreach($q->loadColumn() as $user_id){
 						$recipient_list .= $user_hash[$user_id].", ";
 					}
 					$recipient_list = substr($recipient_list, 0, strlen($recipient_list)-2);


### PR DESCRIPTION
🎯 **What:** Fixed a SQL injection vulnerability in `modules/messages/index.php` caused by directly concatenating raw user input (`$_POST["recipient_user_id"]`) into a query. Extended this fix to cover other unescaped inputs and identifiers in the module.

⚠️ **Risk:** Left unfixed, an attacker could manipulate the POST parameters to inject arbitrary SQL commands. Because this operates on database queries, it could lead to data exfiltration, modification, or even dropping tables, compromising the integrity of the entire platform.

🛡️ **Solution:** The simplest, most idiomatic, and 100% effective solution for numeric IDs in this framework is integer casting. All relevant user input arrays (`$_POST`, `$_GET`) and user IDs passed to `DBQuery->addWhere()` in `index.php`, `vw_messages.php`, and `compose_message.php` are now safely cast to `(int)`. I also fixed a preexisting bug in `vw_messages.php` where `db_loadColumn($sql)` incorrectly used an undefined variable instead of relying on the active query object `$q->loadColumn()`.

---
*PR created automatically by Jules for task [17707356854695618153](https://jules.google.com/task/17707356854695618153) started by @davmont*