### PR TITLE
🔒 Fix SQL Injection in timesheet dosql.php

### DIFF
--- a/modules/timesheet/dosql.php
+++ b/modules/timesheet/dosql.php
@@ -16,7 +16,7 @@ if ($punchIn) {
 	$timesheet = new Timesheet();
 	$q->addTable('timesheet');
 	$q->addQuery('*');
-	$q->addWhere("user_id = $AppUI->user_id and timesheet_date = '" . $_POST['timesheet_date'] . "'");
+	$q->addWhere("user_id = " . (int)$AppUI->user_id . " and timesheet_date = '" . db_escape($_POST['timesheet_date']) . "'");
 
 	if (!$q->loadObject($timesheet)) { // timesheet doesn't exist yet.  Create it.
 		$timesheet->timesheet_id = "";
@@ -41,7 +41,7 @@ if ($punchIn) {
 	$timesheet = new Timesheet();
 	$q->addTable('timesheet');
 	$q->addQuery('*');
-	$q->addWhere("user_id = $AppUI->user_id and timesheet_date = '" . $_POST['timesheet_date'] . "'");
+	$q->addWhere("user_id = " . (int)$AppUI->user_id . " and timesheet_date = '" . db_escape($_POST['timesheet_date']) . "'");
 
 	if (!$q->loadObject($timesheet)) { // timesheet doesn't exist yet.  Create it.
 		$timesheet->timesheet_id = "";
@@ -66,7 +66,7 @@ if ($punchIn) {
 	$timesheet = new Timesheet();
 	$q->addTable('timesheet');
 	$q->addQuery('*');
-	$q->addWhere("user_id = $AppUI->user_id and timesheet_date = '" . $_POST['timesheet_date'] . "'");
+	$q->addWhere("user_id = " . (int)$AppUI->user_id . " and timesheet_date = '" . db_escape($_POST['timesheet_date']) . "'");
 
 	if (!$q->loadObject($timesheet)) { // timesheet doesn't exist yet.  Create it.
 		$timesheet->timesheet_id = "";


### PR DESCRIPTION
🎯 **What:** Fixed SQL injection vulnerabilities in `modules/timesheet/dosql.php` where raw `$_POST` input and uncast user IDs were concatenated directly into a database query string.

⚠️ **Risk:** Left unfixed, an attacker could manipulate the `timesheet_date` POST variable to inject arbitrary SQL statements. This could lead to data exfiltration, database manipulation, or unauthorized access to other users' timesheets by bypassing the user ID checks.

🛡️ **Solution:** The fix casts `$AppUI->user_id` to an integer `(int)` and sanitizes `$_POST['timesheet_date']` using the application's built-in `db_escape()` function before appending it to the `DBQuery->addWhere()` condition. This secures the query against SQL injection while maintaining legacy functional behavior. The fix was applied identically to all three vulnerable call sites (`$punchIn`, `$punchOut`, and `$break`).

---
*PR created automatically by Jules for task [13225469027179710648](https://jules.google.com/task/13225469027179710648) started by @davmont*