### PR TITLE
🔒 Fix SQL injection vulnerability in timesheet dosql.php

### DIFF
--- a/modules/timesheet/dosql.php
+++ b/modules/timesheet/dosql.php
@@ -16,7 +16,7 @@ if ($punchIn) {
 	$timesheet = new Timesheet();
 	$q->addTable('timesheet');
 	$q->addQuery('*');
-	$q->addWhere("user_id = $AppUI->user_id and timesheet_date = '" . $_POST['timesheet_date'] . "'");
+	$q->addWhere("user_id = " . (int)$AppUI->user_id . " and timesheet_date = '" . db_escape($_POST['timesheet_date']) . "'");
 
 	if (!$q->loadObject($timesheet)) { // timesheet doesn't exist yet.  Create it.
 		$timesheet->timesheet_id = "";
@@ -41,7 +41,7 @@ if ($punchIn) {
 	$timesheet = new Timesheet();
 	$q->addTable('timesheet');
 	$q->addQuery('*');
-	$q->addWhere("user_id = $AppUI->user_id and timesheet_date = '" . $_POST['timesheet_date'] . "'");
+	$q->addWhere("user_id = " . (int)$AppUI->user_id . " and timesheet_date = '" . db_escape($_POST['timesheet_date']) . "'");
 
 	if (!$q->loadObject($timesheet)) { // timesheet doesn't exist yet.  Create it.
 		$timesheet->timesheet_id = "";
@@ -66,7 +66,7 @@ if ($punchIn) {
 	$timesheet = new Timesheet();
 	$q->addTable('timesheet');
 	$q->addQuery('*');
-	$q->addWhere("user_id = $AppUI->user_id and timesheet_date = '" . $_POST['timesheet_date'] . "'");
+	$q->addWhere("user_id = " . (int)$AppUI->user_id . " and timesheet_date = '" . db_escape($_POST['timesheet_date']) . "'");
 
 	if (!$q->loadObject($timesheet)) { // timesheet doesn't exist yet.  Create it.
 		$timesheet->timesheet_id = "";


### PR DESCRIPTION
🎯 **What:** The `modules/timesheet/dosql.php` file had a SQL injection vulnerability where `$_POST['timesheet_date']` and `$AppUI->user_id` were directly concatenated into queries.

⚠️ **Risk:** An attacker could exploit this to inject arbitrary SQL commands via the `timesheet_date` POST parameter, potentially compromising the database or retrieving sensitive information since the input was unescaped.

🛡️ **Solution:** The queries using `addWhere` were modified across the file. `$AppUI->user_id` is now explicitly cast to an integer `(int)$AppUI->user_id`, and `$_POST['timesheet_date']` is now properly escaped using the application's built-in `db_escape()` function before being concatenated. This prevents SQL injection attacks without altering the intended application logic.

---
*PR created automatically by Jules for task [13821513748077716718](https://jules.google.com/task/13821513748077716718) started by @davmont*