### PR TITLE
🔒 fix: resolve SQL injection in inventory quick filter

### DIFF
--- a/modules/inventory/index.php
+++ b/modules/inventory/index.php
@@ -37,17 +37,28 @@ $titleBlock = new CTitleBlock( 'Inventory', "../modules/inventory/images/48_my_c
 if ( isset( $_GET[ 'quick_filter' ] ) )
 {
 	$databases = array( "user" => "users", "company" => "companies", "department" => "departments", "project" => "projects" );
-	$sql = new DBQuery();
-	$sql -> addTable($databases[ $_GET[ 'quick_filter' ]]);
-	$sql -> addQuery($_GET[ "quick_filter" ].'_company AS company_id');
-	$sql -> addWhere($_GET[ 'quick_filter' ]."_id=".$_GET[ 'quick_filter_id' ]);
+	$quick_filter = $_GET[ 'quick_filter' ];
 
-	$row = $sql->loadResult();
+	if (array_key_exists($quick_filter, $databases)) {
+		$quick_filter_id = (int) dPgetCleanParam($_GET, 'quick_filter_id', 0);
 
-	$AppUI->setState( 'InventoryIdxFilterCompany', $row[0][ 'company_id' ] );
-	$AppUI->setState( 'InventoryIdxFilterType', $_GET[ 'quick_filter' ] );
-	$AppUI->setState( 'InventoryIdxFilterIndex', $_GET[ 'quick_filter_id' ] );
-	$AppUI->setState( 'InventoryIdxFilterSearch', $_GET[ 'quick_filter_search' ] );
+		$sql = new DBQuery();
+		$sql -> addTable($databases[$quick_filter]);
+		$sql -> addQuery($quick_filter.'_company AS company_id');
+		$sql -> addWhere($quick_filter."_id=".$quick_filter_id);
+
+		$row = $sql->loadList();
+
+		if (!empty($row)) {
+			$AppUI->setState( 'InventoryIdxFilterCompany', $row[0]['company_id'] );
+		} else {
+			$AppUI->setState( 'InventoryIdxFilterCompany', '' );
+		}
+
+		$AppUI->setState( 'InventoryIdxFilterType', $quick_filter );
+		$AppUI->setState( 'InventoryIdxFilterIndex', $quick_filter_id );
+		$AppUI->setState( 'InventoryIdxFilterSearch', dPgetCleanParam($_GET, 'quick_filter_search', '') );
+	}
 }
 
 // retrieve any state parameters


### PR DESCRIPTION
🎯 **What:** The `modules/inventory/index.php` file was vulnerable to SQL injection because raw `$_GET` values (`quick_filter` and `quick_filter_id`) were concatenated directly into a `DBQuery` object to form table names, column names, and conditions.

⚠️ **Risk:** An attacker could exploit this to inject arbitrary SQL commands. This could allow unauthorized access to database tables, data exfiltration, or modification/deletion of application data, posing a severe security risk.

🛡️ **Solution:** 
- Validated the `quick_filter` parameter strictly using an allowlist approach (`array_key_exists` against a known map of valid table prefixes).
- Sanitized `quick_filter_id` by explicitly casting it to an integer `(int)` and using the framework's built-in `dPgetCleanParam`.
- Added defensive `empty()` checks before interacting with query result arrays to prevent fatal TypeErrors in modern PHP versions.
- Replaced the erroneous `loadResult()` method call with `loadList()`, properly matching the subsequent array-index accesses (`$row[0]['company_id']`) expected by legacy application logic.

---
*PR created automatically by Jules for task [4039817452074379009](https://jules.google.com/task/4039817452074379009) started by @davmont*