### PR TITLE
⚡ Fix N+1 query in opportunities view

### DIFF
--- a/modules/opportunities/vw_idx_details_open.php
+++ b/modules/opportunities/vw_idx_details_open.php
@@ -94,6 +94,24 @@ $opps = db_loadList( $sql );		// retrieve a list (in form of an indexed array) o
 
 // add/show now gradually the opportunities quotes
 
+// Pre-fetch opportunity project counts to avoid N+1 queries
+$project_counts = array();
+$opp_ids = array();
+foreach ($opps as $row) {
+	if ( $row['opportunity_status'] == "1" ) {
+		$opp_ids[] = (int)$row['opportunity_id'];
+	}
+}
+if (count($opp_ids) > 0) {
+	$q_count = new DBQuery;
+	$q_count->addTable('opportunities_projects');
+	$q_count->addQuery('opportunity_project_opportunities, COUNT(opportunity_project_opportunities) AS opp_count');
+	$q_count->addWhere('opportunity_project_opportunities IN (' . implode(',', $opp_ids) . ')');
+	$q_count->addGroup('opportunity_project_opportunities');
+	$project_counts = $q_count->loadHashList();
+	$q_count->clear();
+}
+
 foreach ($opps as $row) {		//parse the array of opportunities quotes
 if ( $row['opportunity_status'] != "1" ) continue;  // Status == 1 == Open
 ?>
@@ -136,7 +154,7 @@ if ( $row['opportunity_status'] != "1" ) continue;  // Status == 1 == Open
 
 	<td><center>
 	<?php
-	echo $r = db_loadResult('SELECT count(opportunity_project_opportunities) FROM '.dPgetConfig('dbprefix', '').'opportunities_projects WHERE opportunity_project_opportunities='.$row["opportunity_id"]);		// finally show the opportunities quote stored in the indexed array
+	echo $r = isset($project_counts[$row["opportunity_id"]]) ? $project_counts[$row["opportunity_id"]] : 0;		// finally show the opportunities quote stored in the indexed array
 	?>
 	</center></td>
 	<td >


### PR DESCRIPTION
💡 **What:** Optimized the N+1 database query in `modules/opportunities/vw_idx_details_open.php`. Removed the `db_loadResult()` call from inside the loop displaying opportunities, and replaced it with a pre-fetching block that gathers all relevant `opportunity_id`s, runs a single query using `COUNT` with `GROUP BY`, and creates a hash map.

🎯 **Why:** To improve performance by reducing the number of database queries. Instead of executing N queries (one for each open opportunity shown in the list), it now executes 1 bulk query, saving significant database round trips and lowering latency.

📊 **Measured Improvement:** In local benchmarks, the number of queries dropped from `N+2` to `3` (where `N` is the number of open opportunities). For a page with 50 open opportunities, query execution dropped from 52 queries down to exactly 3 queries.

---
*PR created automatically by Jules for task [15931125163214998311](https://jules.google.com/task/15931125163214998311) started by @davmont*