### PR TITLE
🧹 [Code Health] Add missing validation checks to CHelpDeskItem::check()

### DIFF
--- a/modules/bugspray/helpdesk.class.php
+++ b/modules/bugspray/helpdesk.class.php
@@ -75,11 +75,19 @@ class CHelpDeskItem extends CDpObject {
     if ($this->item_id === NULL) {
       return 'Help Desk item id is NULL';
     }
+    if (empty($this->item_title)) {
+      return 'Help Desk item title cannot be blank';
+    }
+    if (empty($this->item_requestor)) {
+      return 'Help Desk item requestor cannot be blank';
+    }
+    if (empty($this->item_summary)) {
+      return 'Help Desk item summary cannot be blank';
+    }
     if (!$this->item_created) { 
       $this->item_created = db_unix2dateTime( time() );
     }
     
-    // TODO More checks
     return NULL;
   }
 


### PR DESCRIPTION
🎯 **What:** The `check()` method inside `modules/bugspray/helpdesk.class.php` was missing checks that enforce the requirement of `item_title`, `item_requestor`, and `item_summary` to match the client-side validation logic. This patch removes the `TODO More checks` comment and adds validation logic checking if these properties are empty.
💡 **Why:** By moving these validations to the server side in `check()`, this ensures the object behaves robustly even when updated via non-form APIs and preserves data integrity.
✅ **Verification:** A PHP syntax check (`php -l`) and the full unit test suite (`php tests/cli_runner.php`) were executed successfully. Code review confirmed safety without introducing backwards incompatibilities.
✨ **Result:** A more complete and secure implementation of the `CHelpDeskItem` object lifecycle.

---
*PR created automatically by Jules for task [3832663114508366854](https://jules.google.com/task/3832663114508366854) started by @davmont*