### PR TITLE
🧹 Remove obsolete Edit separation TODO in contacts module

### DIFF
--- a/modules/contacts/index.php
+++ b/modules/contacts/index.php
@@ -172,7 +172,6 @@ if ($canAuthor) {
 		. $AppUI->_('Import vCard') . '</a>');
 }
 $titleBlock->show();
-// TODO: Check to see that the Edit function is separated.
 
 ?>
 <script language="javascript" type="text/javascript">


### PR DESCRIPTION
🎯 **What:** Removed the obsolete `TODO: Check to see that the Edit function is separated.` comment from `modules/contacts/index.php`.
💡 **Why:** The comment is outdated. The "Edit" function logic has already been correctly separated to the `addedit.php` controller as indicated by the route `?m=contacts&a=addedit`. Removing the comment cleans up the codebase and prevents confusion.
✅ **Verification:**
- Validated that `index.php` contains no syntax errors (`php -l`).
- Ran the test suite (`php tests/cli_runner.php`) which passed successfully.
- Code review passed.
✨ **Result:** Cleaned up outdated `TODO` comments, improving maintainability.

---
*PR created automatically by Jules for task [11884622297188323993](https://jules.google.com/task/11884622297188323993) started by @davmont*