### PR TITLE
🧹 Fix missing administrator ACL access in permissions upgrade

### DIFF
--- a/db/upgrade_permissions.php
+++ b/db/upgrade_permissions.php
@@ -136,8 +136,7 @@ $perms->add_acl($login_perms, null, array($role), null, null, 1, 1, null, null, 
 
 // Administrator has ALL on ALL
 $perms->add_acl($all_perms, null, array($admin_role), null, array($all_mods), 1, 1, null, null, 'user');
-$perms->add_acl($access_perms, null, array($admin_role), $acl_perms, null, 1, 1, null, null, 'user');
-// TODO:  Add the administrator ACL access.
+$perms->add_acl($all_perms, null, array($admin_role), $acl_perms, null, 1, 1, null, null, 'user');
 
 // Guest has view on ALL
 $perms->add_acl($view_perms, null, array($guest_role), null, array($non_admin_mods), 1, 1, null, null, 'user');


### PR DESCRIPTION
🎯 **What:** The TODO comment "Add the administrator ACL access" has been resolved by updating the `$perms->add_acl` call for the `$admin_role` and `$acl_perms` to use the `$all_perms` array rather than just `$access_perms`.
💡 **Why:** Giving the administrator role full permissions (`access`, `add`, `edit`, `view`, `delete`) on the `sys->acl` object ensures that administrators have the ability to fully manage ACL permissions as intended. Resolving the TODO cleans up the code base and prevents confusion regarding incomplete functionality.
✅ **Verification:** Verified syntax with `php -l db/upgrade_permissions.php` and ran the core test suite `php tests/cli_runner.php` which completed with 0 errors and failures.
✨ **Result:** Improved maintainability and correctness of ACL initialization during db install/upgrade.

---
*PR created automatically by Jules for task [17283283280554421965](https://jules.google.com/task/17283283280554421965) started by @davmont*