### PR TITLE
🧹 [Code Health] Add Untabbed View Support to Invoices Module

### DIFF
--- a/modules/invoices/index.php
+++ b/modules/invoices/index.php
@@ -71,14 +71,14 @@ if ($canEdit) {
 	);
 }
 $titleBlock->show();
-// TODO Add support for untabbed view
-/*
-if ( $tabBox->isTabbed() ) {
-        $tabBox->add("vw_all", "All");
-}
-*/
+
 // tabbed information boxes
 $tabBox = new CTabBox("?m=invoices&orderby=$orderby", "{$dPconfig['root_dir']}/modules/invoices/", $tab);
+
+if ( $tabBox->isTabbed() ) {
+	$tabBox->add("vw_all", "All");
+}
+
 $tabBox->add('vw_idx_open', 'Open Invoices');
 $tabBox->add('vw_idx_paid', 'Paid Invoices');
 $tabBox->show();

--- a/modules/invoices/vw_all.php
+++ b/modules/invoices/vw_all.php
@@ -1,0 +1,64 @@
+<?php /* INVOICES $Id: vw_all.php $ */
+global $AppUI, $invoices, $company_id;
+$df = $AppUI->getPref('SHDATEFORMAT');
+?>
+
+<table width="100%" border="0" cellpadding="3" cellspacing="1" class="tbl">
+	<tr>
+		<td align="right" width="65" nowrap="nowrap">&nbsp;<?php echo $AppUI->_('sort by'); ?>:&nbsp;</td>
+		<th nowrap="nowrap">
+			<a href="?m=invoices&orderby=invoice_id" class="hdr"><?php echo $AppUI->_('Invoice ID'); ?></a>
+		</th>
+		<th nowrap="nowrap">
+			<a href="?m=invoices&orderby=invoice_company" class="hdr"><?php echo $AppUI->_('Company'); ?>:</a>
+		</th>
+		<th nowrap="nowrap">
+			<a href="?m=invoices&orderby=invoice_status" class="hdr"><?php echo $AppUI->_('Status'); ?>:</a>
+		</th>
+		<th nowrap="nowrap">
+			<a href="?m=invoices&orderby=invoice_grand_total" class="hdr"><?php echo $AppUI->_('Total'); ?></a>
+		</th>
+		<th nowrap="nowrap">
+			<a href="?m=invoices&orderby=invoice_date%20desc" class="hdr"><?php echo $AppUI->_('Invoice Date'); ?></a>
+			<a href="?m=invoices&orderby=invoice_due%20desc" class="hdr">(<?php echo $AppUI->_('Invoice Due'); ?>)</a>
+		</th>
+	</tr>
+
+	<?php
+	$CR = "\n";
+	$CT = "\n\t";
+	$none = true;
+	$grandTotal = 0;
+	foreach ($invoices as $row) {
+		$none = false;
+		$grandTotal = ($grandTotal ?? 0) + $row["invoice_grand_total"];
+		$invoice_date = intval(@$row["invoice_date"]) ? new CDate($row["invoice_date"]) : null;
+		$invoice_due = intval(@$row["invoice_due"]) ? new CDate($row["invoice_due"]) : null;
+
+		$s = '<tr>';
+		$s .= '<td width="65">&nbsp;</td>';
+		$s .= $CR . '<td align="right">';
+		$s .= $CT . '<a href="?m=invoices&a=view&invoice_id=' . $row["invoice_id"] . '">' . $row["invoice_id"] . '</a>';
+		$s .= $CR . '</td>';
+		$s .= $CR . '<td width="100%" nowrap="nowrap">' . $row["company_name"] . '</td>';
+		$s .= $CR . '<td width="100%" nowrap="nowrap">' . ($row["invoice_status"] == 1 ? $AppUI->_('Paid') : $AppUI->_('Open')) . '</td>';
+		$s .= $CR . '<td align="right" nowrap="nowrap">';
+		$s .= $CT . $row["invoice_grand_total"];
+		$s .= $CR . '</td>';
+		$s .= $CR . '<td align="right" nowrap="nowrap">';
+		$s .= $CT . ($invoice_date ? $invoice_date->format($df) : '-');
+		$s .= $CT . '(' . ($invoice_due ? $invoice_due->format($df) : '-') . ')';
+		$s .= $CR . '</td>';
+		$s .= $CR . '</tr>';
+		echo $s;
+	}
+	if ($none) {
+		echo $CR . '<tr><td colspan="6">' . $AppUI->_('No invoices available') . '</td></tr>';
+	} else {
+		echo $CR . '<tr><td colspan="4" align=right>Total=</td><td align="right" nowrap="nowrap">' . sprintf("%01.2f", $grandTotal) . '</td><td>&nbsp;</td></tr>';
+	}
+	?>
+	<tr>
+		<td colspan="6">&nbsp;</td>
+	</tr>
+</table>


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The TODO comment in `modules/invoices/index.php` asking to "Add support for untabbed view" has been resolved by uncommenting the associated code and creating the required view file.

💡 **Why:** How this improves maintainability
The TODO comment existed for a long time representing an incomplete feature or an unfinished refactor. By resolving it, we complete the untabbed functionality which ensures the module behaves consistently with others (like companies, hosting, resources, files) that support flat/untabbed lists, and we remove dead/commented code.

✅ **Verification:** How you confirmed the change is safe
- Ran `php -l` on the modified `index.php` and the newly created `vw_all.php`. No syntax errors.
- Ran the full `cli_runner.php` test suite. All tests pass successfully (0 failures, 0 errors).
- Verified the structure of `vw_all.php` matches the existing views (`vw_idx_open.php` and `vw_idx_paid.php`), specifically its use of the global `$invoices` array populated in `index.php`.

✨ **Result:** The improvement achieved
The "All" (untabbed) view is now functional in the Invoices module. It will correctly show a combined list of invoices with a "Status" column denoting whether they are "Paid" or "Open". The codebase is cleaner with the removal of the commented-out block and the TODO item.

---
*PR created automatically by Jules for task [10664815086826596086](https://jules.google.com/task/10664815086826596086) started by @davmont*