### PR TITLE
🧹 Refactor static ausql query to DBQuery in tasks

### DIFF
--- a/modules/tasks/tasks.php
+++ b/modules/tasks/tasks.php
@@ -2,7 +2,6 @@
 if (!defined('DP_BASE_DIR')) {
 	die('You should not access this file directly.');
 }
-//TODO: Convert Static Queries
 
 global $m, $a, $project_id, $macroproject_id, $f, $min_view, $query_string, $durnTypes;
 global $task_sort_item1, $task_sort_type1, $task_sort_order1;
@@ -351,22 +350,26 @@ if (!empty($all_task_ids)) {
 	$task_id_list = implode(',', $all_task_ids);
 
 	//add information about assigned users into the page output
-	$ausql = ('SELECT ut.task_id, ut.user_id, u.user_username, contact_email, ut.perc_assignment, '
-		. 'SUM(ut.perc_assignment) AS assign_extent, contact_first_name, contact_last_name '
-		. 'FROM ' . $dbprefix . 'user_tasks ut LEFT JOIN ' . $dbprefix . 'users u ON u.user_id = ut.user_id '
-		. 'LEFT JOIN ' . $dbprefix . 'contacts ON u.user_contact = contact_id '
-		. 'WHERE ut.task_id IN (' . $task_id_list . ') GROUP BY ut.task_id, ut.user_id '
-		. 'ORDER BY ut.perc_assignment desc, u.user_username');
+	$q = new DBQuery;
+	$q->addQuery('ut.task_id, ut.user_id, u.user_username, contact_email, ut.perc_assignment, '
+		. 'SUM(ut.perc_assignment) AS assign_extent, contact_first_name, contact_last_name');
+	$q->addTable('user_tasks', 'ut');
+	$q->leftJoin('users', 'u', 'u.user_id = ut.user_id');
+	$q->leftJoin('contacts', '', 'u.user_contact = contact_id');
+	$q->addWhere('ut.task_id IN (' . $task_id_list . ')');
+	$q->addGroup('ut.task_id, ut.user_id');
+	$q->addOrder('ut.perc_assignment desc, u.user_username');
 
-	$paurc = db_exec($ausql);
-	$nnums = db_num_rows($paurc);
+	$paurc = $q->exec();
 	echo db_error();
 
 	$task_users_map = array();
-	for ($xx = 0; $xx < $nnums; $xx++) {
-		$u_row = db_fetch_assoc($paurc);
-		$task_users_map[$u_row['task_id']][] = $u_row;
+	if ($paurc) {
+		while ($u_row = db_fetch_assoc($paurc)) {
+			$task_users_map[$u_row['task_id']][] = $u_row;
+		}
 	}
+	$q->clear();
 
 	// Assign users to tasks
 	foreach ($projects as $k => &$p) {


### PR DESCRIPTION
This Pull Request addresses code health improvements by converting static raw SQL strings to the application's standard `DBQuery` query builder in `modules/tasks/tasks.php`.

🎯 **What:** The `//TODO: Convert Static Queries` comment was addressed. Specifically, the static `$ausql` query (used for fetching assigned users on tasks) was rewritten utilizing the `DBQuery` object class. 

💡 **Why:** Migrating raw SQL construction to the system's `DBQuery` component enhances maintainability and consistency.

✅ **Verification:**
- Ran `php -l modules/tasks/tasks.php` to verify syntax.
- Addressed code review feedback confirming that the dynamic `$tsql` string is unsuitable for `DBQuery` builder migration (it produces malformed SQL like `INNER JOIN ON LEFT JOIN`) and should be left as-is, focusing on the purely static `$ausql` query instead.
- Confirmed that explicit `LEFT JOIN` semantics were preserved in the converted code to prevent accidental regression (hidden assignment records).
- All related test cases run cleanly via `php tests/cli_runner.php`.

✨ **Result:** Enhanced the codebase with more robust and idiomatic database interactions while preserving existing application logic completely.

---
*PR created automatically by Jules for task [11652537555565380460](https://jules.google.com/task/11652537555565380460) started by @davmont*