### PR TITLE
🧹 Refactor error handling in gantt_pdf.php

### DIFF
--- a/modules/tasks/gantt_pdf.php
+++ b/modules/tasks/gantt_pdf.php
@@ -1299,11 +1299,10 @@ $show_gantt = 1;
 			<?php 
 
 		} else {
-			//TODO: create error handler for permission problems
-			
-			echo "Could not open file to save PDF.  ";
-			if (!is_writable( $temp_dir ))
-				echo "The files/temp directory is not writable.  Check your file system permissions.";
+			$AppUI->setMsg("Could not open file to save PDF.", UI_MSG_ERROR);
+			if (!is_writable( $temp_dir )) {
+				$AppUI->setMsg("The files/temp directory is not writable.  Check your file system permissions.", UI_MSG_ERROR, true);
+			}
 		}
 
 		$_POST['printpdf'] = '0';


### PR DESCRIPTION
🎯 **What:** The raw `echo` error messages related to file/directory permissions in `modules/tasks/gantt_pdf.php` were replaced with standard `$AppUI->setMsg(..., UI_MSG_ERROR)` calls. The obsolete `//TODO: create error handler for permission problems` comment was also removed.
💡 **Why:** Outputting raw text using `echo` interrupts standard flow and page layout. The standard error handling approach in dotProject/web2Project is to add messages to `$AppUI->setMsg()`, which stores them and displays them cleanly according to the UI layout. This improves maintainability and consistency.
✅ **Verification:** Verified changes visually with `php -l` and manual inspection. Standard test suite was executed to ensure no regressions were introduced.
✨ **Result:** Improved and consistent error handling for permission issues when generating PDF files.

---
*PR created automatically by Jules for task [4928164903594136033](https://jules.google.com/task/4928164903594136033) started by @davmont*