### PR TITLE
🧹 chore: remove unused variables and stale TODO in tasks

### DIFF
--- a/modules/tasks/tasks.php
+++ b/modules/tasks/tasks.php
@@ -294,11 +294,6 @@ if ($search_text = $AppUI->getState('searchtext')) {
 }
 
 // filter tasks considering task and project permissions
-$projects_filter = '';
-$tasks_filter = '';
-
-// TODO: Enable tasks filtering
-
 $allowedProjects = $project->getAllowedSQL($AppUI->user_id, 'task_project');
 if (count($allowedProjects)) {
 	$where .= ' AND ' . implode(' AND ', $allowedProjects);


### PR DESCRIPTION
🎯 **What:** Removed unused variables `$projects_filter` and `$tasks_filter` and a stale `// TODO: Enable tasks filtering` comment from `modules/tasks/tasks.php`.
💡 **Why:** The comment is stale as task filtering via permissions is already actively applied right below the comment. Leaving dead code and stale TODOs creates confusion and degrades maintainability.
✅ **Verification:** Verified that existing functionality is completely preserved. The removed variables were entirely unused and the TODO was stale. Ran the PHP syntax check, reviewed diffs, and executed the automated test suite successfully.
✨ **Result:** Improved codebase maintainability by cleaning up unused variables and stale speculative comments, leaving only active logic without altering behavior.

---
*PR created automatically by Jules for task [17819865194080620745](https://jules.google.com/task/17819865194080620745) started by @davmont*