### PR TITLE
🧹 Fix missing description file handling in reports modules

### DIFF
--- a/modules/macroprojects/reports.php
+++ b/modules/macroprojects/reports.php
@@ -97,22 +97,24 @@ if ($report_type) {
 		$type = str_replace('.php', '', $v);
 		$desc_file = $type . '.' . $AppUI->user_locale . '.txt';
 		
+		$desc = array();
 		// Load the description file for the user locale, default to 'en'
 		if (file_exists(DP_BASE_DIR . '/modules/macroprojects/reports/' . $desc_file)) {
 			$desc = file(DP_BASE_DIR . '/modules/macroprojects/reports/' . $desc_file);
 			
 		} else {
 			$desc_file_en = $type . '.en.txt';
-			//FIXME : need to handle description file non existence
-			$desc = file(DP_BASE_DIR.'/modules/macroprojects/reports/'.$desc_file_en);
+			if (file_exists(DP_BASE_DIR . '/modules/macroprojects/reports/' . $desc_file_en)) {
+				$desc = file(DP_BASE_DIR.'/modules/macroprojects/reports/'.$desc_file_en);
+			}
 		}
 		
 		echo ("<tr>\n");
 		echo ('<td><a href="index.php?m=macroprojects&a=reports&macroproject_id=' . $macroproject_id 
 		      . '&report_type=' . $type . ((isset($desc[2])) ? ('&' . $desc[2]) : '') . '">');
-		echo (($desc[0]) ? $desc[0] : $v);
+		echo ((!empty($desc[0])) ? $desc[0] : $v);
 		echo ('</a></td>' . "\n");
-		echo '<td>' . (@$desc[1] ? '- ' . $desc[1] : '') . "</td>\n";
+		echo '<td>' . (!empty($desc[1]) ? '- ' . $desc[1] : '') . "</td>\n";
 		echo "</tr>\n";
 	}
 	echo '</table>';

--- a/modules/projects/reports.php
+++ b/modules/projects/reports.php
@@ -93,22 +93,24 @@ if ($report_type) {
 		$type = str_replace('.php', '', $v);
 		$desc_file = $type . '.' . $AppUI->user_locale . '.txt';
 		
+		$desc = array();
 		// Load the description file for the user locale, default to 'en'
 		if (file_exists(DP_BASE_DIR . '/modules/projects/reports/' . $desc_file)) {
 			$desc = file(DP_BASE_DIR . '/modules/projects/reports/' . $desc_file);
 			
 		} else {
 			$desc_file_en = $type . '.en.txt';
-			//FIXME : need to handle description file non existence
-			$desc = file(DP_BASE_DIR.'/modules/projects/reports/'.$desc_file_en);
+			if (file_exists(DP_BASE_DIR . '/modules/projects/reports/' . $desc_file_en)) {
+				$desc = file(DP_BASE_DIR.'/modules/projects/reports/'.$desc_file_en);
+			}
 		}
 		
 		echo ("<tr>\n");
 		echo ('<td><a href="index.php?m=projects&a=reports&project_id=' . $project_id 
 		      . '&report_type=' . $type . ((isset($desc[2])) ? ('&' . $desc[2]) : '') . '">');
-		echo (($desc[0]) ? $desc[0] : $v);
+		echo ((!empty($desc[0])) ? $desc[0] : $v);
 		echo ('</a></td>' . "\n");
-		echo '<td>' . (@$desc[1] ? '- ' . $desc[1] : '') . "</td>\n";
+		echo '<td>' . (!empty($desc[1]) ? '- ' . $desc[1] : '') . "</td>\n";
 		echo "</tr>\n";
 	}
 	echo '</table>';


### PR DESCRIPTION
🎯 **What:** Fixed missing description file handling in `modules/macroprojects/reports.php` and `modules/projects/reports.php`. Addressed FIXME comments.
💡 **Why:** The previous code blindly attempted to `file()` a fallback `.en.txt` file even if it didn't exist, and relied on error suppression (`@`) or direct access (`$desc[0]`) which triggers PHP warnings/notices when both files are absent. This change explicitly checks `file_exists()`, initializes an empty array, and uses `!empty()` to safely display content, improving reliability and logs cleanliness.
✅ **Verification:** Verified syntax with `php -l`. Visually confirmed modifications with `sed`. Ran full test suite via `tests/cli_runner.php` and confirmed 13/13 passing tests. Code passed review.
✨ **Result:** Code health is improved as we properly handle edge cases where a description file may not exist. We removed obsolete FIXME comments and prevented PHP notices/warnings.

---
*PR created automatically by Jules for task [12878839497102692695](https://jules.google.com/task/12878839497102692695) started by @davmont*