### PR TITLE
🧹 Fix closure delete permissions and standardizes method signatures

### DIFF
--- a/modules/closure/closure.class.php
+++ b/modules/closure/closure.class.php
@@ -39,7 +39,7 @@ class CClosure extends CDpObject {
 		return $result;
 	}
 	
-		function store() {
+		function store($updateNulls = false) {
 		$this->dPTrimAll();
 
 		$msg = $this->check();
@@ -67,15 +67,33 @@ class CClosure extends CDpObject {
 		}
 	}
 	
-	function canDelete( &$msg, $oid=null ) {
-		// TODO: check if user permissions are considered when deleting a project
+	function canDelete( &$msg, $oid=null, $joins=null ) {
 		global $AppUI;
 		$perms =& $AppUI->acl();
 
-		return $perms->checkModuleItem('closure', 'delete', $oid);
+		$id = $oid ? (int)$oid : (int)$this->pma_id;
+
+		if (!$perms->checkModuleItem('closure', 'delete', $id)) {
+			$msg = $AppUI->_('noDeletePermission');
+			return false;
+		}
+
+		$q = new DBQuery;
+		$q->addTable('post_mortem_analysis', 'pma');
+		$q->addQuery('p1.project_id');
+		$q->addJoin('projects', 'p1', 'p1.project_name = pma.project_name');
+		$q->addWhere("pma.pma_id = " . $id);
+		$project_id = $q->loadResult();
+
+		if ($project_id && !$perms->checkModuleItem('projects', 'edit', $project_id)) {
+			$msg = $AppUI->_('noDeletePermission');
+			return false;
+		}
+
+		return true;
 	}
 
-	function delete($oid = NULL) {
+	function delete($oid = null, $history_desc = '', $history_proj = 0) {
 		$k = $this->_tbl_key;
 		if ($oid) {
 			$this->$k = intval($oid);
@@ -87,11 +105,11 @@ class CClosure extends CDpObject {
 		}
 
 		$this->load($oid);
-		addHistory('post_mortem_analysis', $this->pma_id, 'delete', $this->project_name);
+		addHistory('post_mortem_analysis', $this->pma_id, 'delete', $this->project_name, $history_proj);
 
 		$q = new DBQuery;
 		$q->setDelete('post_mortem_analysis');
-		$q->addWhere('pma_id ='.$this->pma_id);
+		$q->addWhere('pma_id =' . (int)$this->pma_id);
 
 		$result = ((!$q->exec())?db_error():NULL);
 		$q->clear();


### PR DESCRIPTION
🎯 **What:** Implemented the missing user permission check when deleting a closure (post-mortem analysis). Standardized method signatures and fixed a potential SQL injection vulnerability in the delete query.
💡 **Why:** The codebase contained a TODO to ensure user permissions are verified before deleting a closure. This improves security and aligns the `CClosure` class with the base `CDpObject` implementation.
✅ **Verification:** Verified syntax with `php -l`. Ran the `tests/cli_runner.php` test suite to ensure no regressions. Visually inspected the code changes to ensure they are correct and follow established patterns.
✨ **Result:** The `delete` operation now securely verifies permissions and safely executes the database query. Method signatures are now compliant with the parent class.

---
*PR created automatically by Jules for task [8789710083168188212](https://jules.google.com/task/8789710083168188212) started by @davmont*