### PR TITLE
⚡ Optimize project deletion by reducing N+1 queries

### DIFF
--- a/modules/projects/projects.class.php
+++ b/modules/projects/projects.class.php
@@ -142,13 +142,13 @@ class CProject extends CDpObject
 		$sql = $q->prepare();
 		$q->clear();
 		$tasks_to_delete = db_loadColumn($sql);
-		foreach ($tasks_to_delete as $task_id) {
+		if (count($tasks_to_delete) > 0) {
 			$q->setDelete('user_tasks');
-			$q->addWhere('task_id =' . $task_id);
+			$q->addWhere('task_id IN (' . implode(',', $tasks_to_delete) . ')');
 			$q->exec();
 			$q->clear();
 			$q->setDelete('task_dependencies');
-			$q->addWhere('dependencies_req_task_id =' . $task_id);
+			$q->addWhere('dependencies_req_task_id IN (' . implode(',', $tasks_to_delete) . ')');
 			$q->exec();
 			$q->clear();
 		}


### PR DESCRIPTION
### 💡 What: The optimization implemented
Optimized the `delete` method in `modules/projects/projects.class.php` by replacing a loop that executed individual `DELETE` queries for each task associated with a project. Instead of $2N$ queries (where $N$ is the number of tasks), the new implementation uses 2 bulk `DELETE` queries with an `IN` clause.

### 🎯 Why: The performance problem it solves
The original implementation suffered from an N+1 query problem. When deleting a project, the code would first fetch all task IDs and then loop through them, executing two separate `DELETE` queries (`user_tasks` and `task_dependencies`) for every single task. This led to significant database overhead and slow project deletions, especially for large projects with many tasks.

### 📊 Measured Improvement:
I established a baseline using a custom benchmark script (`benchmark_delete_optimization.php`) that mocked the environment.
- **Baseline (10 tasks):** 25 total queries executed.
- **Optimized (10 tasks):** 7 total queries executed.
- **Improvement:** 18 queries saved (72% reduction) for 10 tasks.
- **Scaling:** For a project with 100 tasks, the improvement would be 198 queries saved (205 queries down to 7).

Functionality was verified by running the existing test suite (`php tests/cli_runner.php`) and performing syntax checks.

---
*PR created automatically by Jules for task [4791483199371871081](https://jules.google.com/task/4791483199371871081) started by @davmont*