### PR TITLE
Verify user permissions on project deletion in closure module

### DIFF
--- a/modules/closure/closure.class.php
+++ b/modules/closure/closure.class.php
@@ -22,9 +22,9 @@ class CClosure extends CDpObject {
 		var $improvement_suggestions = null;
 		var $conclusions = null;
 
-  function __construct() {
-    parent::__construct('post_mortem_analysis', 'pma_id');
-  }
+	function __construct() {
+		parent::__construct('post_mortem_analysis', 'pma_id', 'closure');
+	}
   
  	function load($oid=null , $strip = true) {
 		$result = parent::load($oid, $strip);
@@ -67,12 +67,40 @@ class CClosure extends CDpObject {
 		}
 	}
 	
-	function canDelete( &$msg, $oid=null ) {
-		// TODO: check if user permissions are considered when deleting a project
+	function canDelete(&$msg, $oid = null, $joins = null) {
 		global $AppUI;
-		$perms =& $AppUI->acl();
 
-		return $perms->checkModuleItem('closure', 'delete', $oid);
+		if (!parent::canDelete($msg, $oid, $joins)) {
+			return false;
+		}
+
+		if (!$oid) {
+			$oid = $this->pma_id;
+		}
+
+		if ($oid) {
+			$q = new DBQuery();
+			$q->addTable('post_mortem_analysis');
+			$q->addQuery('project_name');
+			$q->addWhere('pma_id = ' . (int)$oid);
+			$project_name = $q->loadResult();
+			$q->clear();
+
+			if ($project_name) {
+				$q->addTable('projects');
+				$q->addQuery('project_id');
+				$q->addWhere('project_name = ?', array($project_name));
+				$project_id = (int)$q->loadResult();
+				$q->clear();
+
+				if ($project_id && !$AppUI->acl()->checkModuleItem('projects', 'edit', $project_id)) {
+					$msg = $AppUI->_('noDeletePermission');
+					return false;
+				}
+			}
+		}
+
+		return true;
 	}
 
 	function delete($oid = NULL) {


### PR DESCRIPTION
Implemented project-level permission verification in the closure module's `canDelete` method. The update ensures that deleting a Post Mortem Analysis record requires 'edit' permissions on the parent project, in addition to 'delete' permissions on the closure item itself. The solution uses the `DBQuery` class for secure data retrieval and the `$AppUI->acl()` object for consistent permission enforcement.

---
*PR created automatically by Jules for task [4581619348179435702](https://jules.google.com/task/4581619348179435702) started by @davmont*