### PR TITLE
🔒 Security fix: Replace dangerous eval() calls with safe alternatives

### DIFF
--- a/lib/phpgacl/test_suite/phpunit/phpunit.php
+++ b/lib/phpgacl/test_suite/phpunit/phpunit.php
@@ -354,7 +354,6 @@ class TestSuite /* implements Test */ {
           }
         }
       }
-      }
     }
     else {  // PHP3
       $dummy = new $classname("dummy");
@@ -522,7 +521,7 @@ class TextTestResult extends TestResult {
 
 	    $exceptions = $failure->getExceptions();
 	    print("<ul>");
-	    foreach ($exceptions as $na => $exception)
+	    foreach ($exceptions as $na => $exception) {
 		printf("<li>%s\n", $exception->getMessage());
         }
 	    print("</ul>");
@@ -599,7 +598,7 @@ class PrettyTestResult extends TestResult {
 
       $exceptions = $failure->getExceptions();
       print("<ul>");
-      foreach ($exceptions as $na => $exception)
+      foreach ($exceptions as $na => $exception) {
 	printf("<li>%s\n", $exception->getMessage());
       }
       print("</ul>");

--- a/modules/calendar/addedit.php
+++ b/modules/calendar/addedit.php
@@ -209,7 +209,7 @@ var calendarField = '';
 
 function popCalendar(field) {
 	calendarField = field;
-	idate = eval('document.editFrm.event_' + field + '.value');
+	idate = document.editFrm['event_' + field].value;
 	window.open('?m=public&a=calendar&dialog=1&callback=setCalendar&date=' + idate, 'calwin', 'top=250,left=250,width=250, height=240,scrollbars=no,status=no');
 }
 
@@ -218,8 +218,8 @@ function popCalendar(field) {
  *	@param string Formatted date
  */
 function setCalendar(idate, fdate) {
-	fld_date = eval('document.editFrm.event_' + calendarField);
-	fld_fdate = eval('document.editFrm.' + calendarField);
+	fld_date = document.editFrm['event_' + calendarField];
+	fld_fdate = document.editFrm[calendarField];
 	fld_date.value = idate;
 	fld_fdate.value = fdate;
 

--- a/modules/calendar/clash.php
+++ b/modules/calendar/clash.php
@@ -111,7 +111,7 @@ var calendarField = '';
 
 function popCalendar(field) {
 	calendarField = field;
-	idate = eval('document.editFrm.event_' + field + '.value');
+	idate = document.editFrm['event_' + field].value;
 	window.open('?m=public&a=calendar&dialog=1&callback=setCalendar&date=' + idate, 'calwin', 'top=250,left=250,width=250, height=220, scrollbars=no, status=no');
 }
 
@@ -120,8 +120,8 @@ function popCalendar(field) {
  *	@param string Formatted date
  */
 function setCalendar(idate, fdate) {
-	fld_date = eval('document.editFrm.event_' + calendarField);
-	fld_fdate = eval('document.editFrm.' + calendarField);
+	fld_date = document.editFrm['event_' + calendarField];
+	fld_fdate = document.editFrm[calendarField];
 	fld_date.value = idate;
 	fld_fdate.value = fdate;
 }

--- a/modules/helpdesk/helpdesk.class.php
+++ b/modules/helpdesk/helpdesk.class.php
@@ -354,7 +354,7 @@ function notify($type, $log_msg, $email_list=null) {
 	}
 	// Build basic information provided in all notifications
 	if (strcmp($HELPDESK_CONFIG['email_header'],"NONE")<>0) {
-		$body .= $HELPDESK_CONFIG{'email_header'} . "\n";
+		$body .= $HELPDESK_CONFIG['email_header'] . "\n";
 	}
 	$body .= $AppUI->_('Issue')." #{$this->item_id}  -  {$this->item_title} " . "\n";
 	$body .= "-----------------------------------------\n";
@@ -487,7 +487,7 @@ function notify($type, $log_msg, $email_list=null) {
 	$count=0;
 	$status_changes_summary="";
 	foreach($field_event_map as $key => $value){
-	   if (eval("return  (isset(\$this->$value) && (\$hditem->$value != \$this->$value));")) {
+	   if (isset($this->$value) && ($hditem->$value != $this->$value)) {
 		$old = $new = "";
 		$skipnotify = NULL;
 		
@@ -603,7 +603,7 @@ function notify($type, $log_msg, $email_list=null) {
 	              break;
 		}// end of switch
 		// if value has changed, add it to the summary of changes.
-		if(!eval("return \$new == \$old;")){
+		if ($new != $old) {
 			if ($new=='') {$new = ' ';}
 			$last_status_comment = $this->log_status($key, $old, $new);
 			// Added by KP to be able to skip event notifications -

--- a/modules/holiday/addedit.php
+++ b/modules/holiday/addedit.php
@@ -68,12 +68,12 @@ if($holiday_white == -1)
 var calendarField = '';
 function popCalendar( field ){
         calendarField = field;
-        idate = eval( 'document.AddEdit.log_' + field + '.value' );
+        idate = document.AddEdit['log_' + field].value;
         window.open( 'index.php?m=public&a=calendar&dialog=1&callback=setCalendar&date=' + idate, 'calwin', 'width=250, height=220, scollbars=false' );
 }
 function setCalendar( idate, fdate ) {
-        fld_date = eval( 'document.AddEdit.log_' + calendarField );
-        fld_fdate = eval( 'document.AddEdit.' + calendarField );
+        fld_date = document.AddEdit['log_' + calendarField];
+        fld_fdate = document.AddEdit[calendarField];
         fld_date.value = idate;
         fld_fdate.value = fdate;
 }


### PR DESCRIPTION
The task was to fix a security vulnerability involving `eval()` in `modules/calendar/clash.php`. Upon investigation, similar dangerous patterns were found in `modules/calendar/addedit.php`, `modules/holiday/addedit.php`, and `modules/helpdesk/helpdesk.class.php`. All identified `eval()` calls were replaced with secure alternatives. Additionally, minor PHP 8 compatibility fixes were applied to the helpdesk module and the test suite to ensure the project remains functional and testable.

---
*PR created automatically by Jules for task [1606078023983696520](https://jules.google.com/task/1606078023983696520) started by @davmont*