### PR TITLE
🧹 Remove commented-out dependency check in testing module

### DIFF
--- a/modules/testing/do_test_aed.php
+++ b/modules/testing/do_test_aed.php
@@ -23,12 +23,6 @@ $del = dPgetParam( $_POST, 'del', 0 );
 
 
 if ($del) {
-	// check if there are dependencies on this object (not relevant for test, left here for show-purposes)
-//	if (!$obj->canDelete( $msg )) {
-//		$AppUI->setMsg( $msg, UI_MSG_ERROR );
-//		$AppUI->redirect();
-//	}
-
 	// see how easy it is to run database commands with the object oriented architecture !
 	// simply delete a quote from db and have detailed error or success report
 	if (($msg = $obj->delete())) {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed dead, commented-out code in `modules/testing/do_test_aed.php` that was previously left for demonstration purposes but is no longer needed.

💡 **Why:** How this improves maintainability
Improves readability and reduces cognitive load by removing irrelevant comments and non-functional code blocks that clutter the core logic of the testing module.

✅ **Verification:** How you confirmed the change is safe
- Visual inspection of the file content.
- Syntax check using `php -l`.
- Successful execution of the full test suite (`php tests/cli_runner.php`).

✨ **Result:** The improvement achieved
A cleaner, more concise `do_test_aed.php` file that strictly contains the necessary logic for its operations.

---
*PR created automatically by Jules for task [6431010940926308422](https://jules.google.com/task/6431010940926308422) started by @davmont*