### PR TITLE
🧪 Add unit tests for SQLAuthenticator::authenticate

### DIFF
--- a/tests/SQLAuthenticatorTest.php
+++ b/tests/SQLAuthenticatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+require_once dirname(__FILE__) . '/../classes/authenticator.class.php';
+
+class SQLAuthenticatorTest extends TestCase {
+
+    function setUp() {
+        // Reset mock state before each test
+        DBQuery::$mockResults = array();
+        DBQuery::$mockExecReturns = true;
+    }
+
+    function testAuthenticateSuccess() {
+        $username = 'testuser';
+        $password = 'password123';
+        $hashedPassword = md5($password);
+        $userId = 42;
+
+        // Mock query result
+        DBQuery::$mockResults = array(
+            array('user_id' => $userId, 'user_password' => $hashedPassword)
+        );
+
+        $auth = new SQLAuthenticator();
+        $result = $auth->authenticate($username, $password);
+
+        $this->assert($result, "Authentication should succeed with correct credentials");
+        $this->assertEquals($userId, $auth->user_id, "User ID should be correctly set on success");
+    }
+
+    function testAuthenticateWrongPassword() {
+        $username = 'testuser';
+        $correctPassword = 'password123';
+        $wrongPassword = 'wrongpassword';
+        $hashedPassword = md5($correctPassword);
+        $userId = 42;
+
+        // Mock query result with correct hash
+        DBQuery::$mockResults = array(
+            array('user_id' => $userId, 'user_password' => $hashedPassword)
+        );
+
+        $auth = new SQLAuthenticator();
+        $result = $auth->authenticate($username, $wrongPassword);
+
+        $this->assert(!$result, "Authentication should fail with incorrect password");
+    }
+
+    function testAuthenticateUserNotFound() {
+        $username = 'nonexistent';
+        $password = 'anypassword';
+
+        // Mock empty query result
+        DBQuery::$mockResults = array();
+
+        $auth = new SQLAuthenticator();
+        $result = $auth->authenticate($username, $password);
+
+        $this->assert(!$result, "Authentication should fail if user is not found");
+    }
+
+    function testAuthenticateQueryError() {
+        $username = 'testuser';
+        $password = 'password123';
+
+        // Simulate query execution failure
+        DBQuery::$mockExecReturns = false;
+
+        $auth = new SQLAuthenticator();
+        $result = $auth->authenticate($username, $password);
+
+        $this->assert(!$result, "Authentication should fail if database query fails");
+    }
+
+    function testUserId() {
+        $auth = new SQLAuthenticator();
+        $auth->user_id = 99;
+
+        $this->assertEquals(99, $auth->userId(), "userId() should return the stored user_id");
+    }
+}
+?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,10 +46,39 @@ if (!class_exists('DBQuery')) {
         var $query = array();
         var $where = array();
 
+        static $mockResults = array();
+        static $mockExecReturns = true;
+
         function addTable($table) { $this->tables[] = $table; }
         function addQuery($field) { $this->query[] = $field; }
-        function addWhere($where) { $this->where[] = $where; }
-        function loadResult() { return ''; } // Return empty for now
+        function addWhere($where, $params = array()) { $this->where[] = $where; }
+
+        function exec() {
+            return self::$mockExecReturns;
+        }
+
+        function fetchRow() {
+            if (empty(self::$mockResults)) {
+                return false;
+            }
+            return array_shift(self::$mockResults);
+        }
+
+        function clear() {
+            $this->tables = array();
+            $this->query = array();
+            $this->where = array();
+        }
+
+        function loadResult() {
+            $row = $this->fetchRow();
+            $this->clear();
+            if ($row === false) {
+                return '';
+            }
+            return is_array($row) ? reset($row) : $row;
+        }
+
         function quote($str) { return "'" . addslashes($str) . "'"; }
     }
 }


### PR DESCRIPTION
This PR addresses the missing tests for the `authenticate` method in the `SQLAuthenticator` class.

### 🎯 What:
- Added comprehensive unit tests for `SQLAuthenticator::authenticate`.
- Improved the `DBQuery` mock in the test suite to support more realistic database interaction simulation.

### 📊 Coverage:
The new `SQLAuthenticatorTest` covers:
- **Successful Authentication**: Verifies that correct credentials return `true` and set the `user_id`.
- **Wrong Password**: Verifies that incorrect passwords return `false`.
- **User Not Found**: Verifies that non-existent usernames return `false`.
- **Database Query Error**: Verifies that authentication fails gracefully if the database query fails.
- **userId Method**: Verifies the simple getter for `user_id`.

### ✨ Result:
Increased test coverage for critical authentication logic, ensuring reliability and preventing regressions in the authentication process. All 18 tests in the suite (including the 5 new ones) pass successfully.

---
*PR created automatically by Jules for task [6193892717690034880](https://jules.google.com/task/6193892717690034880) started by @davmont*