### PR TITLE
🧹 Code Health Improvement: Remove Debug Code in Authenticator Class

### DIFF
--- a/classes/authenticator.class.php
+++ b/classes/authenticator.class.php
@@ -341,7 +341,6 @@ if (!defined('DP_BASE_DIR')) {
 				$c->contact_zip = $ldap_attribs["postalcode"][0];
 				$c->contact_job = $ldap_attribs["title"][0];
 
-				//print_r($c); die();
 				db_insertObject('contacts', $c, 'contact_id');
 			}
 			$contact_id = ($c->contact_id == NULL) ? "NULL" : $c->contact_id;


### PR DESCRIPTION
🎯 **What:** Removed a commented-out debug line (`//print_r($c); die();`) in the `createsqluser` method of the `LDAPAuthenticator` class.
💡 **Why:** This improves maintainability by removing unnecessary dead code that was used for debugging during development and was left in the codebase.
✅ **Verification:** Verified that the code was correctly removed. Ran the test suite (`php tests/cli_runner.php`) which completed successfully without any failures, ensuring no regressions.
✨ **Result:** A cleaner `authenticator.class.php` file without stray debug comments.

---
*PR created automatically by Jules for task [6578944024659631313](https://jules.google.com/task/6578944024659631313) started by @davmont*