### PR TITLE
🔒 Fix SQL Injection in annotations addedit.php

### DIFF
--- a/modules/annotations/addedit.php
+++ b/modules/annotations/addedit.php
@@ -177,7 +177,13 @@ if ($changed_show_date != "") $show_date=$changed_show_date;
 	
 // format dates
 	$df = $AppUI->getPref('SHDATEFORMAT');            //this is the way dates should be handled! 
-	if ($show_date=="0" && $annotation_id > 0) $show_date = substr(db_LoadResult("SELECT annotation_date FROM annotations WHERE annotation_id=".$annotation_id),0,10);
+	if ($show_date=="0" && $annotation_id > 0) {
+		$q = new DBQuery();
+		$q->addTable('annotations');
+		$q->addQuery('annotation_date');
+		$q->addWhere('annotation_id = ' . (int)$annotation_id);
+		$show_date = substr($q->loadResult(), 0, 10);
+	}
 	if ($show_date=="0") $show_date = date('Ymd');
 	$oDate = new CDate($show_date); //the Date Object
 
@@ -316,7 +322,11 @@ if ($save_annotations == "1") {
 		$obj->store();  // normal store method, defined in the class....
 		$msg="Annotation inserted";	//The OK Message, see line around 129
 	} else {	//changed value --> update
-		$obj->annotation_date = db_loadResult("SELECT annotation_date FROM annotations WHERE annotation_id=".$obj->annotation_id);
+		$q->clear();
+		$q->addTable('annotations');
+		$q->addQuery('annotation_date');
+		$q->addWhere('annotation_id = ' . (int)$obj->annotation_id);
+		$obj->annotation_date = $q->loadResult();
 		//die($obj->annotation_date );
 		$obj->store();
 		$msg="Annotation altered (ID ".$obj->annotation_id.")";	//The OK Message, see line around 129
@@ -616,7 +626,14 @@ $tmpdigit = dPgetSysVal( 'AnnotationsPoints' );	 //the dP will get the sysval fo
 			$presets_from = "No Presets! Values already set."; // String to show, where the preset of the 6V is coming from
 			// We need the latest anno ( --> Get all, sort DESC) which is different from this one ( annotation_date != this_annos_date )
 				if ( $obj->annotation_project > 0 ) { // only if we've already got a project !
-					$preset_values = mysql_fetch_assoc( mysql_query( 'SELECT * FROM annotations WHERE annotation_project='.$obj->annotation_project.' AND annotation_date != "'.$obj->annotation_date.'" ORDER BY annotation_date DESC'));
+					$q->clear();
+					$q->addTable('annotations');
+					$q->addQuery('*');
+					$q->addWhere('annotation_project = ' . (int)$obj->annotation_project);
+					$q->addWhere('annotation_date != ' . $q->quote($obj->annotation_date));
+					$q->addOrder('annotation_date DESC');
+					$preset_values = $q->loadHash();
+
 					// If something was altered:
 					if (	$obj->annotation_strategy == NULL ||	$obj->annotation_sholders == NULL ||	$obj->annotation_risks == NULL
 						||	$obj->annotation_sizing == NULL ||	$obj->annotation_horizontality == NULL ||	$obj->annotation_costbenefit == NULL)
@@ -633,7 +650,12 @@ $tmpdigit = dPgetSysVal( 'AnnotationsPoints' );	 //the dP will get the sysval fo
 			// ********** If there are no Values --> try to get them out of Details   ( Anno -> Details -> Opps ) ***************************************************************************
 					// We need the right detail:   detail_project = annotation_project
 					if ( $obj->annotation_project > 0 ) { // if there is an related Project  ( ?? Which one should be taken ??)
-						$preset_values = mysql_fetch_assoc( mysql_query( 'SELECT detail_id,detail_project,detail_strategy,detail_sholders,detail_risks,detail_sizing,detail_horizontality,detail_costbenefit FROM details WHERE detail_project='.$obj->annotation_project));
+						$q->clear();
+						$q->addTable('details');
+						$q->addQuery('detail_id,detail_project,detail_strategy,detail_sholders,detail_risks,detail_sizing,detail_horizontality,detail_costbenefit');
+						$q->addWhere('detail_project = ' . (int)$obj->annotation_project);
+						$preset_values = $q->loadHash();
+
 						// If something was altered:
 						if (	$obj->annotation_strategy == NULL ||	$obj->annotation_sholders == NULL ||	$obj->annotation_risks == NULL
 							||	$obj->annotation_sizing == NULL ||	$obj->annotation_horizontality == NULL ||	$obj->annotation_costbenefit == NULL)
@@ -650,16 +672,25 @@ $tmpdigit = dPgetSysVal( 'AnnotationsPoints' );	 //the dP will get the sysval fo
 				// ********** If there are no Values --> try to get them out of opportunities   ( Anno -> Details -> Opps ) ***************************************************************************
 					if ($obj->annotation_project > 0) { // if project has already been selected
 						// We need the opportunity id.    We can get it, if there is an opportuntiy  which relates to this project (annotation_project)!:
-						$aPreset_values = ( mysql_query( 'SELECT opportunity_project_opportunities FROM opportunities_projects WHERE opportunity_project_projects='.$obj->annotation_project ));
-						if ( $aPreset_values ) { // If there is data available
-							$preset_values = mysql_fetch_assoc( $aPreset_values );
+						$q->clear();
+						$q->addTable('opportunities_projects');
+						$q->addQuery('opportunity_project_opportunities');
+						$q->addWhere('opportunity_project_projects = ' . (int)$obj->annotation_project);
+						$preset_values = $q->loadHash();
+
+						if ( $preset_values ) { // If there is data available
 							// If something was altered:
 							if (	$obj->annotation_strategy == NULL ||	$obj->annotation_sholders == NULL ||	$obj->annotation_risks == NULL
 								||	$obj->annotation_sizing == NULL ||	$obj->annotation_horizontality == NULL ||	$obj->annotation_costbenefit == NULL)
 								$presets_from = "From <a href='index.php?m=opportunities&a=addedit&opportunity_id=".$preset_values['opportunity_project_opportunities']."'>
 												Opportunities ID-".$preset_values['opportunity_project_opportunities']."</a> PID-".$obj->annotation_project;				
 							if ( $preset_values['opportunity_project_opportunities'] > 0 ) { // if there is an related Project  ( ?? Which one should be taken ??)
-								$preset_values = mysql_fetch_assoc( mysql_query( 'SELECT opportunity_strategy,opportunity_sholders,opportunity_risks,opportunity_sizing,opportunity_horizontality,opportunity_costbenefit FROM opportunities WHERE opportunity_id='.$preset_values['opportunity_project_opportunities']));
+								$q->clear();
+								$q->addTable('opportunities');
+								$q->addQuery('opportunity_strategy,opportunity_sholders,opportunity_risks,opportunity_sizing,opportunity_horizontality,opportunity_costbenefit');
+								$q->addWhere('opportunity_id = ' . (int)$preset_values['opportunity_project_opportunities']);
+								$preset_values = $q->loadHash();
+
 								if ($obj->annotation_strategy == NULL) $obj->annotation_strategy = $preset_values['opportunity_strategy'];
 								if ($obj->annotation_sholders == NULL) $obj->annotation_sholders = $preset_values['opportunity_sholders'];
 								if ($obj->annotation_risks == NULL) $obj->annotation_risks = $preset_values['opportunity_risks'];
@@ -724,14 +755,22 @@ $tmpdigit = dPgetSysVal( 'AnnotationsPoints' );	 //the dP will get the sysval fo
 	<tr>
 		<?php // set $checked, try to get presets from last annos, then from details
 			if ( $addnew == "1" ) {		// if we are editing this anno, we don't want to get the preset !!
-				$prev_anno = mysql_query( 'SELECT * FROM annotations WHERE annotation_project="'.$project_id.'" ORDER BY annotation_date DESC' );
-				// Now get the latest values from anno:
-				$prev_values = mysql_fetch_assoc( $prev_anno );
+				$q->clear();
+				$q->addTable('annotations');
+				$q->addQuery('*');
+				$q->addWhere('annotation_project = ' . (int)$project_id);
+				$q->addOrder('annotation_date DESC');
+				$prev_values = $q->loadHash();
+
 				if ($prev_values['annotation_must'] == "1" || $prev_values['annotation_must'] == "0") { 
 					$obj->annotation_must = $prev_values['annotation_must'];
 				} ELSE {
-					$prev_detail = mysql_query( 'SELECT * FROM details WHERE detail_project="'.$project_id.'"' );
-					$prev_values = mysql_fetch_assoc( $prev_detail );
+					$q->clear();
+					$q->addTable('details');
+					$q->addQuery('*');
+					$q->addWhere('detail_project = ' . (int)$project_id);
+					$prev_values = $q->loadHash();
+
 					if ($prev_values['detail_must'] == "1" || $prev_values['detail_must'] == "0") { $obj->annotation_must = $prev_values['detail_must']; }
 					// ELse : there are no presets available
 				}
@@ -740,7 +779,11 @@ $tmpdigit = dPgetSysVal( 'AnnotationsPoints' );	 //the dP will get the sysval fo
 		?>
 		<td align="center" nowrap="nowrap">
 			<?php // Get the priority out of project table:
-				$prio = db_loadResult('SELECT project_priority FROM projects WHERE project_id='.$obj->annotation_project);
+				$q->clear();
+				$q->addTable('projects');
+				$q->addQuery('project_priority');
+				$q->addWhere('project_id = ' . (int)$obj->annotation_project);
+				$prio = $q->loadResult();
 				if ( $obj->annotation_revised_priority == NULL ) $obj->annotation_revised_priority = $prio;
 				// Show Projects Priority and Select Revised Priority
 				echo $AppUI->_('Project Priority is')." : <b>".$priorities[$prio]."</b>&nbsp;&nbsp;||&nbsp;&nbsp;".$AppUI->_('Revised Priority')." : "; echo arraySelect( $priorities,'annotation_revised_priority','size=1 class=text ',$obj->annotation_revised_priority); ?>			


### PR DESCRIPTION
🎯 **What:** Fixed multiple SQL Injection vulnerabilities in `modules/annotations/addedit.php`.
⚠️ **Risk:** The previous code directly concatenated user-controlled inputs (like `project_id`) into SQL queries, allowing an attacker to execute arbitrary SQL commands, potentially leading to unauthorized data access or modification.
🛡️ **Solution:** Migrated all legacy `mysql_query` and `mysql_fetch_assoc` calls to the standard `DBQuery` class. All inputs are now properly cast to integers or escaped using `$q->quote()`. Verified the fix with syntax checks and the project's test suite.

---
*PR created automatically by Jules for task [11750546006505268417](https://jules.google.com/task/11750546006505268417) started by @davmont*