### PR TITLE
🛡️ Re-integrate and fix permissions in modules/bugspray/vw_log_update.php

### DIFF
--- a/modules/bugspray/vw_log_update.php
+++ b/modules/bugspray/vw_log_update.php
@@ -1,11 +1,12 @@
 <?php /* $Id: vw_log_update.php,v 1.1 2004/05/07 22:28:40 uodeltasig Exp $ */
-GLOBAL $AppUI, $hditem, $ist;
+GLOBAL $AppUI, $hditem, $ist, $canEdit, $m;
 $item_id = dPgetParam( $_GET, 'item_id', 0 );
+
 // check permissions
-//$canEdit = !getDenyEdit( 'tasks', $item_id );
-//if (!$canEdit) {
-//	$AppUI->redirect( "m=public&a=access_denied" );
-//}
+$canEdit = !getDenyEdit( $m, $item_id );
+if (!$canEdit) {
+	$AppUI->redirect( "m=public&a=access_denied" );
+}
 
 $task_log_id = intval( dPgetParam( $_GET, 'task_log_id', 0 ) );
 $log = new CTaskLog();
@@ -24,7 +25,7 @@ $sql = "select distinct task_log_costcode
 $task_log_costcodes = array(""); // Let's add a blank default option
 $task_log_costcodes = array_merge($task_log_costcodes, db_loadColumn($sql));
 
-//if ($canEdit) {
+if ($canEdit) {
 // Task Update Form
 	$df = $AppUI->getPref( 'SHDATEFORMAT' );
 	$log_date = new CDate( $log->task_log_date );
@@ -150,5 +151,4 @@ $task_log_costcodes = array_merge($task_log_costcodes, db_loadColumn($sql));
 
 </form>
 </table>
-<?php //}
-?>
+<?php } ?>


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Re-integrated and corrected functional permission checks in `modules/bugspray/vw_log_update.php` that were previously commented out.

💡 **Why:** How this improves maintainability
Restoring these checks ensures that only users with proper edit permissions can access the task log update form. The previous state (commented out) bypassed these security controls. The restored code was fixed to use the dynamic module variable `$m` and explicit `GLOBAL` declarations, resolving the original reason they were likely disabled (incorrect context/scoping).

✅ **Verification:** How you confirmed the change is safe
- Ran `php -l modules/bugspray/vw_log_update.php` to ensure syntax is correct.
- Verified that required variables (`$m`, `$canEdit`) are properly globalized for inclusion within `CTabBox`.
- Confirmed the logic follows established dotProject/Helpdesk patterns for item-level permissions.

✨ **Result:** The improvement achieved
Security is restored for log updates, and the code is now clean, functional, and correctly integrated with the framework's permission system.

---
*PR created automatically by Jules for task [11474665630611167849](https://jules.google.com/task/11474665630611167849) started by @davmont*