### PR TITLE
Implement missing strftime options in jscalendar

### DIFF
--- a/modules/projectdesigner/jscalendar/calendar.js
+++ b/modules/projectdesigner/jscalendar/calendar.js
@@ -1753,7 +1753,34 @@ Date.prototype.print = function (str) {
 	s["%d"] = (d < 10) ? ("0" + d) : d; // the day of the month (range 01 to 31)
 	s["%e"] = d; // the day of the month (range 1 to 31)
 	// FIXME: %D : american date style: %m/%d/%y
-	// FIXME: %E, %F, %G, %g, %h (man strftime)
+	var jy = y, jm = m + 1, jd = d;
+	if (jm > 2) {
+		jm -= 3;
+	} else {
+		jm += 9;
+		jy--;
+	}
+	var jc = (jy / 100) | 0;
+	var jr = jy % 100;
+	if (jy < 0) {
+		s["%E"] = Math.floor((14609700 * jc + (jr == 0 ? 1 : 0)) / 400) +
+			Math.floor((1461 * jr + 1) / 4) +
+			Math.floor((153 * jm + 2) / 5) +
+			jd + 1721118;
+	} else {
+		s["%E"] = Math.floor(146097 * jc / 4) +
+			Math.floor(1461 * jr / 4) +
+			Math.floor((153 * jm + 2) / 5) +
+			jd + 1721119;
+	}
+	s["%F"] = y + "-" + ((m < 9) ? ("0" + (1+m)) : (1+m)) + "-" + ((d < 10) ? ("0" + d) : d);
+	var d2 = new Date(y, m, d, 12, 0, 0);
+	d2.setDate(d2.getDate() - (w + 6) % 7 + 3);
+	var gy = d2.getFullYear();
+	s["%G"] = gy;
+	s["%g"] = ('' + gy).substr(2, 2);
+	s["%h"] = Calendar._SMN[m];
+
 	s["%H"] = (hr < 10) ? ("0" + hr) : hr; // hour, range 00 to 23 (24h format)
 	s["%I"] = (ir < 10) ? ("0" + ir) : ir; // hour, range 01 to 12 (12h format)
 	s["%j"] = (dy < 100) ? ((dy < 10) ? ("00" + dy) : ("0" + dy)) : dy; // day of the year (range 001 to 366)


### PR DESCRIPTION
I have implemented the missing `strftime` formatting options in `modules/projectdesigner/jscalendar/calendar.js` as requested.

The following options were added:
- `%E`: Julian Day Number (consistent with the project's PHP `Date` library).
- `%F`: ISO 8601 date format (`%Y-%m-%d`).
- `%G`: ISO 8601 week-based year (4 digits).
- `%g`: ISO 8601 week-based year (2 digits).
- `%h`: Abbreviated month name (equivalent to `%b`).

I verified the changes using a Node.js test script that mocked the `Calendar` object and tested various dates, including ISO week-based year boundaries. I also ran the project's existing PHP test suite to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [8291573074334083639](https://jules.google.com/task/8291573074334083639) started by @davmont*