### PR TITLE
🔒 [Fix SQL Injection in mileage_log classes]

### DIFF
--- a/modules/mileagelog/mileagelog.class.php
+++ b/modules/mileagelog/mileagelog.class.php
@@ -83,8 +83,10 @@ class CMileageLog {
 	}
 
 	function load( $mileage_log_id ) {
-		$sql = "SELECT * FROM mileage_log WHERE mileage_log_id = " . intval($mileage_log_id);
-		return db_loadObject( $sql, $this );
+		$q = new DBQuery;
+		$q->addTable('mileage_log');
+		$q->addWhere('mileage_log_id = ' . intval($mileage_log_id));
+		return $q->loadObject($this);
 	}
 
 	function bind( $hash ) {
@@ -120,8 +122,10 @@ class CMileageLog {
 		}
 	}
 	function delete() {
-		$sql = "DELETE FROM mileage_log WHERE mileage_log_id = " . intval($this->mileage_log_id);
-		if (!db_exec( $sql )) {
+		$q = new DBQuery;
+		$q->setDelete('mileage_log');
+		$q->addWhere('mileage_log_id = ' . intval($this->mileage_log_id));
+		if (!$q->exec()) {
 			return db_error();
 		} else {
 			return NULL;
@@ -142,8 +146,10 @@ class CMileageLogPurpose {
 	}
 
 	function load( $mileage_log_purpose_id ) {
-		$sql = "SELECT * FROM mileage_log_purpose WHERE mileage_log_purpose_id = " . intval($mileage_log_purpose_id);
-		return db_loadObject( $sql, $this );
+		$q = new DBQuery;
+		$q->addTable('mileage_log_purpose');
+		$q->addWhere('mileage_log_purpose_id = ' . intval($mileage_log_purpose_id));
+		return $q->loadObject($this);
 	}
 
 	function bind( $hash ) {
@@ -179,8 +185,10 @@ class CMileageLogPurpose {
 		}
 	}
 	function delete() {
-		$sql = "DELETE FROM mileage_log_purpose WHERE mileage_log_purpose_id = " . intval($this->mileage_log_purpose_id);
-		if (!db_exec( $sql )) {
+		$q = new DBQuery;
+		$q->setDelete('mileage_log_purpose');
+		$q->addWhere('mileage_log_purpose_id = ' . intval($this->mileage_log_purpose_id));
+		if (!$q->exec()) {
 			return db_error();
 		} else {
 			return NULL;

--- a/modules/mileagelog/mileagelog.class.php
+++ b/modules/mileagelog/mileagelog.class.php
@@ -83,7 +83,7 @@ class CMileageLog {
 	}
 
 	function load( $mileage_log_id ) {
-		$sql = "SELECT * FROM mileage_log WHERE mileage_log_id = $mileage_log_id";
+		$sql = "SELECT * FROM mileage_log WHERE mileage_log_id = " . intval($mileage_log_id);
 		return db_loadObject( $sql, $this );
 	}
 
@@ -120,7 +120,7 @@ class CMileageLog {
 		}
 	}
 	function delete() {
-		$sql = "DELETE FROM mileage_log WHERE mileage_log_id = $this->mileage_log_id";
+		$sql = "DELETE FROM mileage_log WHERE mileage_log_id = " . intval($this->mileage_log_id);
 		if (!db_exec( $sql )) {
 			return db_error();
 		} else {
@@ -142,7 +142,7 @@ class CMileageLogPurpose {
 	}
 
 	function load( $mileage_log_purpose_id ) {
-		$sql = "SELECT * FROM mileage_log_purpose WHERE mileage_log_purpose_id = $mileage_log_purpose_id";
+		$sql = "SELECT * FROM mileage_log_purpose WHERE mileage_log_purpose_id = " . intval($mileage_log_purpose_id);
 		return db_loadObject( $sql, $this );
 	}
 
@@ -179,7 +179,7 @@ class CMileageLogPurpose {
 		}
 	}
 	function delete() {
-		$sql = "DELETE FROM mileage_log_purpose WHERE mileage_log_purpose_id = $this->mileage_log_purpose_id";
+		$sql = "DELETE FROM mileage_log_purpose WHERE mileage_log_purpose_id = " . intval($this->mileage_log_purpose_id);
 		if (!db_exec( $sql )) {
 			return db_error();
 		} else {


### PR DESCRIPTION
🎯 **What:** Fixed SQL injection vulnerabilities in the `load()` and `delete()` methods of `CMileageLog` and `CMileageLogPurpose` classes where IDs were directly concatenated into SQL queries without sanitization.

⚠️ **Risk:** The lack of input validation allowed arbitrary user input to manipulate SQL statements. This vulnerability could lead to SQL injection, potentially compromising the database, allowing unauthorized data access, modification, or deletion, depending on the privileges of the database user.

🛡️ **Solution:** Used `intval()` to cast the IDs to integers, ensuring that only numerical values are concatenated into the SQL query, thus mitigating the risk of SQL injection.

---
*PR created automatically by Jules for task [6243178711311263844](https://jules.google.com/task/6243178711311263844) started by @davmont*