### PR TITLE
Implement %X formatting option in jscalendar

### DIFF
--- a/modules/projectdesigner/jscalendar/calendar.js
+++ b/modules/projectdesigner/jscalendar/calendar.js
@@ -1801,7 +1801,7 @@ Date.prototype.print = function (str) {
 	s["%u"] = w + 1;	// the day of the week (range 1 to 7, 1 = MON)
 	s["%w"] = w;		// the day of the week (range 0 to 6, 0 = SUN)
 	// FIXME: %x : preferred date representation for the current locale without the time
-	// FIXME: %X : preferred time representation for the current locale without the date
+	s["%X"] = s["%H"] + ":" + s["%M"] + ":" + s["%S"]; // preferred time representation for the current locale without the date
 	s["%y"] = ('' + y).substr(2, 2); // year without the century (range 00 to 99)
 	s["%Y"] = y;		// year with the century
 	s["%%"] = "%";		// a literal '%' character


### PR DESCRIPTION
Implemented the `%X` format code (preferred time representation for the current locale without the date) in `Date.prototype.print` located in `modules/projectdesigner/jscalendar/calendar.js`. It concatenates the pre-calculated hours, minutes, and seconds as a fallback, since standard translated time formats are not available in the plugin's language dictionaries.

---
*PR created automatically by Jules for task [3493809373705638553](https://jules.google.com/task/3493809373705638553) started by @davmont*