### PR TITLE
🔒 Fix SQL injection vulnerability in CTesting delete method

### DIFF
--- a/modules/testing/testing.class.php
+++ b/modules/testing/testing.class.php
@@ -35,12 +35,12 @@ class CTesting extends CDpObject {
 
 	// overload the delete method of the parent class for adaptation for einstein's needs
 	function delete() {
-		$sql = "DELETE FROM unittest WHERE unittest_id = " . intval($this->unittest_id);
-		if (!db_exec( $sql )) {
-			return db_error();
-		} else {
-			return NULL;
-		}
+		$q = new DBQuery();
+		$q->setDelete('unittest');
+		$q->addWhere("unittest_id = " . intval($this->unittest_id));
+		$result = ((!$q->exec()) ? db_error() : NULL);
+		$q->clear();
+		return $result;
 	}
 }
 ?>

--- a/modules/testing/testing.class.php
+++ b/modules/testing/testing.class.php
@@ -35,7 +35,7 @@ class CTesting extends CDpObject {
 
 	// overload the delete method of the parent class for adaptation for einstein's needs
 	function delete() {
-		$sql = "DELETE FROM unittest WHERE unittest_id = $this->unittest_id";
+		$sql = "DELETE FROM unittest WHERE unittest_id = " . intval($this->unittest_id);
 		if (!db_exec( $sql )) {
 			return db_error();
 		} else {


### PR DESCRIPTION
🎯 **What:**
The `delete()` method in `modules/testing/testing.class.php` (`CTesting` class) was vulnerable to SQL Injection. It concatenated `$this->unittest_id` directly into the SQL `DELETE` query without any sanitization or parameterization.

⚠️ **Risk:**
If an attacker could control the `unittest_id` property of a `CTesting` object before `delete()` was called, they could inject arbitrary SQL commands. Depending on database permissions, this could lead to unauthorized data deletion, modification, or exposure across the entire database, not just the `unittest` table.

🛡️ **Solution:**
The fix explicitly casts `$this->unittest_id` to an integer using PHP's `intval()` function before concatenating it into the SQL string:
`$sql = "DELETE FROM unittest WHERE unittest_id = " . intval($this->unittest_id);`
This ensures that only a safe, numeric value is ever passed to the database query, completely neutralizing the injection vector while preserving the intended functionality.

---
*PR created automatically by Jules for task [5100597024099930281](https://jules.google.com/task/5100597024099930281) started by @davmont*