### PR TITLE
🧹 [code health] Remove misleading TODO prefix from upgrade instructions

### DIFF
--- a/db/upgrade_latest.php
+++ b/db/upgrade_latest.php
@@ -163,7 +163,7 @@ function dPupgrade($from_version, $to_version, $last_updated) {
 		case '20101117':
 		case '20110106':
 		case '20120814':
-		// TODO:  Add new versions here.  Keep this message above the default label.
+		// Add new versions here.  Keep this message above the default label.
 		default:
 			break;
 	}


### PR DESCRIPTION
🎯 What
Removed the "TODO:" prefix from a developer instruction comment in `db/upgrade_latest.php`.

💡 Why
The comment `// TODO:  Add new versions here...` is a permanent guideline, not an actual task to be completed. Removing the prefix stops it from polluting TODO lists and being flagged by automated tools.

✅ Verification
Confirmed that only the comment string was modified and no logic changes were made.

✨ Result
Cleaner codebase with fewer false-positive tasks flagged.

---
*PR created automatically by Jules for task [13214216684160835866](https://jules.google.com/task/13214216684160835866) started by @davmont*