### PR TITLE
🔒 [security fix] Fix SQL injection in calendar class queries

### DIFF
--- a/modules/calendar/calendar.class.php
+++ b/modules/calendar/calendar.class.php
@@ -558,7 +558,7 @@ class CEvent extends CDpObject
 			// delete user_events relationship
 			$q = new DBQuery;
 			$q->setDelete('user_events');
-			$q->addWhere('event_id = ' . $this->event_id);
+			$q->addWhere('event_id = ' . (int)$this->event_id);
 			$deleted = ((!$q->exec()) ? $AppUI->_('Could not delete Event-User relationship') . '. ' . db_error() : null);
 			$q->clear;
 		}
@@ -813,7 +813,7 @@ class CEvent extends CDpObject
 		$q->addTable('user_events', 'ue');
 		$q->addTable('contacts', 'con');
 		$q->addQuery('u.user_id, CONCAT_WS(" ",contact_first_name, contact_last_name)');
-		$q->addWhere('ue.event_id = ' . $this->event_id);
+		$q->addWhere('ue.event_id = ' . (int)$this->event_id);
 		$q->addWhere('user_contact = contact_id');
 		$q->addWhere('ue.user_id = u.user_id');
 		$assigned = $q->loadHashList();
@@ -827,7 +827,7 @@ class CEvent extends CDpObject
 
 		$q = new DBQuery;
 		$q->setDelete('user_events');
-		$q->addWhere('event_id = ' . $this->event_id);
+		$q->addWhere('event_id = ' . (int)$this->event_id);
 		$q->exec();
 		$q->clear();
 
@@ -987,7 +987,7 @@ class CEvent extends CDpObject
 		$q->addQuery('ue.user_id');
 		$q->addWhere('ue.event_id IN (' . implode(',', $events) . ')');
 		if ($this->event_id) {
-			$q->addWhere('NOT(ue.event_id = ' . $this->event_id . ')');
+			$q->addWhere('NOT(ue.event_id = ' . (int)$this->event_id . ')');
 		}
 
 		$clashes = $q->loadColumn();


### PR DESCRIPTION
🎯 **What:** The `$this->event_id` property in `modules/calendar/calendar.class.php` was being directly concatenated into a SQL `WHERE` clause without sanitization in several methods (such as `delete()`, `getAssigned()`, `updateAssigned()`, and `getConcurrentEvents()`), leading to SQL injection vulnerabilities.

⚠️ **Risk:** An attacker who can manipulate the `event_id` input could execute arbitrary SQL commands. This could lead to data leakage, modification, or deletion, depending on database permissions and configuration.

🛡️ **Solution:** Modified the vulnerable lines to explicitly cast `$this->event_id` to an integer `(int)` before string concatenation within the `DBQuery->addWhere()` clauses. This ensures that any malicious input provided as the `event_id` is safely neutralized.

---
*PR created automatically by Jules for task [2963030062550764232](https://jules.google.com/task/2963030062550764232) started by @davmont*