### PR TITLE
🔒 [security fix] Prevent SQL Injection in calendar queries

### DIFF
--- a/modules/calendar/calendar.class.php
+++ b/modules/calendar/calendar.class.php
@@ -558,7 +558,7 @@ class CEvent extends CDpObject
 			// delete user_events relationship
 			$q = new DBQuery;
 			$q->setDelete('user_events');
-			$q->addWhere('event_id = ' . $this->event_id);
+			$q->addWhere('event_id = ' . (int)$this->event_id);
 			$deleted = ((!$q->exec()) ? $AppUI->_('Could not delete Event-User relationship') . '. ' . db_error() : null);
 			$q->clear;
 		}
@@ -707,17 +707,17 @@ class CEvent extends CDpObject
 						'user_events',
 						'ue'
 						,
-						'ue.event_id = e.event_id AND ue.user_id =' . $user_id
+						'ue.event_id = e.event_id AND ue.user_id =' . (int)$user_id
 					);
-					$$query_set->addWhere('(ue.user_id = ' . $user_id
+					$$query_set->addWhere('(ue.user_id = ' . (int)$user_id
 						. ') AND (event_private=0 OR event_owner='
-						. $user_id . ')');
+						. (int)$user_id . ')');
 					break;
 				case 'own':
-					$$query_set->addWhere('e.event_owner =' . $user_id);
+					$$query_set->addWhere('e.event_owner =' . (int)$user_id);
 					break;
 				case 'all':
-					$$query_set->addWhere('(e.event_private=0 OR e.event_owner=' . $user_id . ')');
+					$$query_set->addWhere('(e.event_private=0 OR e.event_owner=' . (int)$user_id . ')');
 					break;
 			}
 
@@ -813,7 +813,7 @@ class CEvent extends CDpObject
 		$q->addTable('user_events', 'ue');
 		$q->addTable('contacts', 'con');
 		$q->addQuery('u.user_id, CONCAT_WS(" ",contact_first_name, contact_last_name)');
-		$q->addWhere('ue.event_id = ' . $this->event_id);
+		$q->addWhere('ue.event_id = ' . (int)$this->event_id);
 		$q->addWhere('user_contact = contact_id');
 		$q->addWhere('ue.user_id = u.user_id');
 		$assigned = $q->loadHashList();
@@ -827,7 +827,7 @@ class CEvent extends CDpObject
 
 		$q = new DBQuery;
 		$q->setDelete('user_events');
-		$q->addWhere('event_id = ' . $this->event_id);
+		$q->addWhere('event_id = ' . (int)$this->event_id);
 		$q->exec();
 		$q->clear();
 
@@ -987,7 +987,7 @@ class CEvent extends CDpObject
 		$q->addQuery('ue.user_id');
 		$q->addWhere('ue.event_id IN (' . implode(',', $events) . ')');
 		if ($this->event_id) {
-			$q->addWhere('NOT(ue.event_id = ' . $this->event_id . ')');
+			$q->addWhere('NOT(ue.event_id = ' . (int)$this->event_id . ')');
 		}
 
 		$clashes = $q->loadColumn();


### PR DESCRIPTION
🎯 **What:** Fixed SQL Injection vulnerabilities in `modules/calendar/calendar.class.php`.
⚠️ **Risk:** The `$this->event_id` and `$user_id` properties were concatenated directly into SQL WHERE clauses without proper casting or sanitization. This allows an attacker to inject arbitrary SQL statements by manipulating the event ID or user ID parameters.
🛡️ **Solution:** The solution ensures that `$this->event_id` and `$user_id` are explicitly cast to integers `(int)` before they are used in string concatenation for database queries. This safely neutralizes the vulnerability while preserving correct functionality. The fix was applied across multiple methods in `calendar.class.php` (`delete`, `getEvents`, `getAssigned`, `updateAssigned`, `getEventsForPeriod`) for comprehensive protection.

---
*PR created automatically by Jules for task [5661917196653287380](https://jules.google.com/task/5661917196653287380) started by @davmont*