### PR TITLE
🧪 [testing improvement] Add tests for check_plain

### DIFF
--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -1,0 +1,31 @@
+<?php
+class FilterTest extends TestCase {
+    function testCheckPlain() {
+        // Happy path: no special characters
+        $this->assertEquals('Hello World', check_plain('Hello World'));
+
+        // HTML special characters
+        $this->assertEquals('&lt;script&gt;', check_plain('<script>'));
+        $this->assertEquals('Go to &amp; from', check_plain('Go to & from'));
+        $this->assertEquals('He said &quot;Hello&quot;', check_plain('He said "Hello"'));
+        $this->assertEquals('It&#039;s a test', check_plain("It's a test"));
+        $this->assertEquals('&lt;a href=&quot;http://example.com&quot;&gt;Link&lt;/a&gt;', check_plain('<a href="http://example.com">Link</a>'));
+
+        // UTF-8 characters
+        $this->assertEquals('Héllo', check_plain('Héllo'));
+        $this->assertEquals('こんにちは', check_plain('こんにちは'));
+
+        // Empty string
+        $this->assertEquals('', check_plain(''));
+
+        // Multiline string
+        $input = "Line 1\nLine 2 <br>";
+        $expected = "Line 1\nLine 2 &lt;br&gt;";
+        $this->assertEquals($expected, check_plain($input));
+
+        // Invalid UTF-8 sequence should return empty string (as per implementation or PHP behavior)
+        // \x80 is an invalid start byte in UTF-8
+        $this->assertEquals('', check_plain("\x80"));
+    }
+}
+?>

--- a/tests/run_filter_tests.php
+++ b/tests/run_filter_tests.php
@@ -1,0 +1,19 @@
+<?php
+define('DP_BASE_DIR', realpath(dirname(__FILE__) . '/..'));
+
+// Mock dPgetConfig
+if (!function_exists('dPgetConfig')) {
+    function dPgetConfig($key, $default = null) {
+        return $default;
+    }
+}
+
+require_once DP_BASE_DIR . '/tests/phpunit.php';
+require_once DP_BASE_DIR . '/includes/filter.php';
+require_once DP_BASE_DIR . '/tests/FilterTest.php';
+
+$suite = new TestSuite('FilterTest');
+$result = new TextTestResult();
+$suite->run($result);
+$result->report();
+?>


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `check_plain` utility function, which is critical for preventing XSS by escaping HTML special characters.

📊 **Coverage:** 
- Basic plain text strings.
- HTML special characters (`<`, `>`, `&`, `"`, `'`).
- UTF-8 characters (Western and Asian characters).
- Empty and multiline strings.
- Invalid UTF-8 sequences (ensuring they return an empty string).

✨ **Result:** Increased test coverage for core utility functions, providing a safety net for future refactoring and ensuring consistent behavior across different PHP versions.

---
*PR created automatically by Jules for task [18311235769361367942](https://jules.google.com/task/18311235769361367942) started by @davmont*