### PR TITLE
🔒 [security fix] Prevent SQL Injection in CEvent::delete

### DIFF
--- a/modules/calendar/calendar.class.php
+++ b/modules/calendar/calendar.class.php
@@ -550,6 +550,7 @@ class CEvent extends CDpObject
 	function delete($oid = NULL, $history_desc = '', $history_proj = 0)
 	{
 		global $AppUI;
+		$this->event_id = (int)$this->event_id;
 		// call default delete method first
 		$deleted = parent::delete($this->event_id);
 


### PR DESCRIPTION
🎯 **What:** Fixed an SQL Injection vulnerability in the `delete()` method of `modules/calendar/calendar.class.php`. The class property `$this->event_id` was being concatenated directly into an SQL `WHERE` clause without sanitization.

⚠️ **Risk:** A malicious user could exploit this vulnerability by manipulating the `event_id` to execute arbitrary SQL commands, potentially leading to unauthorized data exposure, modification, or deletion (e.g., deleting relationships other than their own or tampering with the database structure).

🛡️ **Solution:** Explicitly cast `$this->event_id = (int)$this->event_id;` at the beginning of the `delete()` method. This guarantees that all subsequent uses of `$this->event_id` within the method—including the vulnerable `addWhere` clause and the `parent::delete()` call—are safely treated as an integer, closing the injection vector.

---
*PR created automatically by Jules for task [9766857839573046909](https://jules.google.com/task/9766857839573046909) started by @davmont*