### PR TITLE
🧹 Remove deprecated checkFlag function in includes/permissions.php

### DIFF
--- a/includes/permissions.php
+++ b/includes/permissions.php
@@ -32,27 +32,6 @@ function getReadableModule()
 	return null;
 }
 
-// TODO: checkFlag should be depricated as it's old and unused
-/**
- * This function is used to check permissions.
- */
-function checkFlag($flag, $perm_type, $old_flag)
-{
-	if ($old_flag) {
-		return (
-			($flag == PERM_DENY) ||	// permission denied
-			($perm_type == PERM_EDIT && $flag == PERM_READ)	// we ask for editing, but are only allowed to read
-		) ? 0 : 1;
-	} else {
-		if ($perm_type == PERM_READ) {
-			return ($flag != PERM_DENY) ? 1 : 0;
-		} else {
-			// => $perm_type == PERM_EDIT
-			return ($flag == $perm_type) ? 1 : 0;
-		}
-	}
-}
-
 /**
  * This function checks certain permissions for
  * a given module and optionally an item_id.


### PR DESCRIPTION
🎯 **What:** Removed the `checkFlag` function and its associated TODO comment from `includes/permissions.php`.
💡 **Why:** The function was explicitly marked as 'old and unused' in the source code. Removing dead code improves the maintainability and readability of the codebase by reducing clutter and potential confusion.
✅ **Verification:**
- Performed a recursive `grep` across the entire codebase to confirm that there are no remaining calls to `checkFlag`.
- Verified the syntax of `includes/permissions.php` using `php -l`.
- Ran existing tests via `tests/cli_runner.php` and `tests/run_tests.php` to ensure no regressions were introduced.
✨ **Result:** A cleaner `includes/permissions.php` file with one less unused function.

---
*PR created automatically by Jules for task [11492604190147527935](https://jules.google.com/task/11492604190147527935) started by @davmont*