### PR TITLE
🧹 Implement strftime %D in jscalendar

### DIFF
--- a/modules/projectdesigner/jscalendar/calendar.js
+++ b/modules/projectdesigner/jscalendar/calendar.js
@@ -1752,7 +1752,7 @@ Date.prototype.print = function (str) {
 	s["%C"] = 1 + Math.floor(y / 100); // the century number
 	s["%d"] = (d < 10) ? ("0" + d) : d; // the day of the month (range 01 to 31)
 	s["%e"] = d; // the day of the month (range 1 to 31)
-	// FIXME: %D : american date style: %m/%d/%y
+	s["%D"] = (m < 9 ? "0" + (1+m) : (1+m)) + "/" + (d < 10 ? "0" + d : d) + "/" + (y + "").substr(2, 2); // american date style: %m/%d/%y
 	var jy = y, jm = m + 1, jd = d;
 	if (jm > 2) {
 		jm -= 3;
@@ -1802,7 +1802,6 @@ Date.prototype.print = function (str) {
 	s["%w"] = w;		// the day of the week (range 0 to 6, 0 = SUN)
 	s["%y"] = ('' + y).substr(2, 2); // year without the century (range 00 to 99)
 	s["%Y"] = y;		// year with the century
-	s["%D"] = s["%m"] + "/" + s["%d"] + "/" + s["%y"]; // american date style: %m/%d/%y
 	s["%x"] = s["%D"]; // preferred date representation for the current locale without the time
 	s["%X"] = s["%H"] + ":" + s["%M"] + ":" + s["%S"]; // preferred time representation for the current locale without the date
 	s["%c"] = s["%a"] + " " + s["%b"] + " " + s["%e"] + " " + s["%T"] + " " + s["%Y"]; // preferred date and time representation for the current locale


### PR DESCRIPTION
🧹 Implement strftime %D in jscalendar

🎯 **What**
Implemented the American date style `%D` (`%m/%d/%y`) formatting in `calendar.js` and removed the `FIXME` comment.

💡 **Why**
The `%D` token was marked as a `FIXME` at line 1755. Due to the non-recursive nature of the string replacement implementation, `s["%D"]` cannot simply reference `s["%m"]`, `s["%d"]`, and `s["%y"]` at line 1755 because those variables haven't been populated in the `s` dictionary yet. To fix this, the date parts are evaluated inline using the raw integer variables (`m`, `d`, `y`). A duplicate definition of `s["%D"]` further down was safely removed.

✅ **Verification**
Verified via local Node.js script asserting formatting evaluates accurately (`11/15/23` for Nov 15 2023), confirming no `undefined` substrings are present. Checked test suite (`php tests/cli_runner.php`) execution to verify no new regressions were introduced.

✨ **Result**
Dates formatted with the `%D` token evaluate properly according to standard strftime rules in `calendar.js`.

---
*PR created automatically by Jules for task [9201267258224596867](https://jules.google.com/task/9201267258224596867) started by @davmont*