### PR TITLE
🧪 [testing improvement] Add tests for CDate::getAMPM

### DIFF
--- a/classes/date.class.php
+++ b/classes/date.class.php
@@ -135,7 +135,7 @@ class CDate extends Date {
 	}
 	
 	function getAMPM() {
-		return (($this->getHour() > 11) ? 'pm' : 'am');
+		return $this->format('%p');
 	}
 	
 	/* Return date obj for the end of the next working day

--- a/tests/CDateTest.php
+++ b/tests/CDateTest.php
@@ -78,6 +78,20 @@ class CDateTest extends TestCase {
         $this->assertEquals(-1, $diff, "Difference with invalid date should be -1");
     }
 
+    function testGetAMPM() {
+        $date = new CDate('2023-01-01 00:00:00');
+        $this->assertEquals('am', $date->getAMPM(), "00:00 should be am");
+
+        $date = new CDate('2023-01-01 11:59:59');
+        $this->assertEquals('am', $date->getAMPM(), "11:59 should be am");
+
+        $date = new CDate('2023-01-01 12:00:00');
+        $this->assertEquals('pm', $date->getAMPM(), "12:00 should be pm");
+
+        $date = new CDate('2023-01-01 23:59:59');
+        $this->assertEquals('pm', $date->getAMPM(), "23:59 should be pm");
+    }
+
 }
 
 ?>


### PR DESCRIPTION
I have added unit tests for the `CDate::getAMPM` method in `tests/CDateTest.php`. The tests cover 00:00 (am), 11:59 (am), 12:00 (pm), and 23:59 (pm).

Additionally, I refactored the `getAMPM` method in `classes/date.class.php` to use the internal `format('%p')` method. I verified in `lib/PEAR/Date.php` that `%p` correctly returns lowercase 'am' or 'pm', which maintains the existing behavior of the method while using a more standard approach.

All tests in `CDateTest.php` pass successfully.

---
*PR created automatically by Jules for task [12986472548607417050](https://jules.google.com/task/12986472548607417050) started by @davmont*