### PR TITLE
⚡ [optimize task assignee deletion performance]

### DIFF
--- a/modules/unitcost/patch_203/tasks/tasks.class.php
+++ b/modules/unitcost/patch_203/tasks/tasks.class.php
@@ -1344,19 +1344,22 @@ class CTask extends CDpObject {
 
                 // delete all current entries from $cslist
                 if ($del == true && $rmUsers == true) {
-                        foreach ($tarr as $user_id) {
-                                if ($user_id > '') {
-                                        $sql = "DELETE FROM user_tasks WHERE task_id = $this->task_id
-                                                AND user_id = $user_id";
-                                        db_exec( $sql );
-                                }
+                        $user_ids = array_filter(array_map('intval', $tarr));
+                        if (count($user_ids) > 0) {
+                                $q = new DBQuery;
+                                $q->setDelete('user_tasks');
+                                $q->addWhere('task_id = ' . (int)$this->task_id);
+                                $q->addWhere('user_id IN (' . implode(',', $user_ids) . ')');
+                                $q->exec();
                         }
 
                          return false;
 
                 } else if ($del == true) {      // delete all on this task for a hand-over of the task
-                        $sql = "DELETE FROM user_tasks WHERE task_id = $this->task_id";
-                        db_exec( $sql );
+                        $q = new DBQuery;
+                        $q->setDelete('user_tasks');
+                        $q->addWhere('task_id = ' . (int)$this->task_id);
+                        $q->exec();
                 }
 
 


### PR DESCRIPTION
💡 **What:** Optimized the `updateAssigned` method in `CTask` by replacing a loop of individual `DELETE` statements with a single bulk `DELETE` query using an `IN` clause.

🎯 **Why:** The previous implementation executed one `DELETE` query per user being unassigned from a task, leading to N database roundtrips. This optimization reduces the database overhead to a single query. The implementation now uses the `DBQuery` class, which is the project's standard ADODB wrapper, ensuring safer and more maintainable code.

📊 **Measured Improvement:**
- Baseline: 5 database calls for 5 users.
- Optimized: 1 database call for 5 users.
- Improvement: 80% reduction in database calls for this scenario.
- Security: Improved by using `DBQuery` and explicit type casting.

---
*PR created automatically by Jules for task [10319112240738614356](https://jules.google.com/task/10319112240738614356) started by @davmont*