### PR TITLE
🧹 [calendar] Replace HTML entity hack with proper decoding utility

### DIFF
--- a/lib/calendar/calendar.js
+++ b/lib/calendar/calendar.js
@@ -185,6 +185,17 @@ Calendar.createElement = function(type, parent) {
 	return el;
 };
 
+Calendar.htmlDecode = function(text) {
+	if (typeof text != "string") {
+		return text;
+	}
+	if (!Calendar._decode_el) {
+		Calendar._decode_el = document.createElement("div");
+	}
+	Calendar._decode_el.innerHTML = text;
+	return Calendar._decode_el.textContent || Calendar._decode_el.innerText || text;
+};
+
 // END: UTILITY FUNCTIONS
 
 // BEGIN: CALENDAR STATIC FUNCTIONS
@@ -615,13 +626,7 @@ Calendar.prototype.create = function (_par) {
 		Calendar._add_evs(cell);
 		cell.calendar = cal;
 		cell.navtype = navtype;
-		if (text.substr(0, 1) != "&") {
-			cell.appendChild(document.createTextNode(text));
-		}
-		else {
-			// FIXME: dirty hack for entities
-			cell.innerHTML = text;
-		}
+		cell.appendChild(document.createTextNode(Calendar.htmlDecode(text)));
 		return cell;
 	};
 

--- a/modules/monitoringandcontrol/js/jsLibraries/calendar/calendar.js
+++ b/modules/monitoringandcontrol/js/jsLibraries/calendar/calendar.js
@@ -192,6 +192,17 @@ Calendar.createElement = function(type, parent) {
 	return el;
 };
 
+Calendar.htmlDecode = function(text) {
+	if (typeof text != "string") {
+		return text;
+	}
+	if (!Calendar._decode_el) {
+		Calendar._decode_el = document.createElement("div");
+	}
+	Calendar._decode_el.innerHTML = text;
+	return Calendar._decode_el.textContent || Calendar._decode_el.innerText || text;
+};
+
 // END: UTILITY FUNCTIONS
 
 // BEGIN: CALENDAR STATIC FUNCTIONS
@@ -641,13 +652,7 @@ Calendar.prototype.create = function (_par) {
 		Calendar._add_evs(cell);
 		cell.calendar = cal;
 		cell.navtype = navtype;
-		if (text.substr(0, 1) != "&") {
-			cell.appendChild(document.createTextNode(text));
-		}
-		else {
-			// FIXME: dirty hack for entities
-			cell.innerHTML = text;
-		}
+		cell.appendChild(document.createTextNode(Calendar.htmlDecode(text)));
 		return cell;
 	};
 

--- a/modules/timeplanning/js/jsLibraries/calendar/calendar.js
+++ b/modules/timeplanning/js/jsLibraries/calendar/calendar.js
@@ -192,6 +192,17 @@ Calendar.createElement = function(type, parent) {
 	return el;
 };
 
+Calendar.htmlDecode = function(text) {
+	if (typeof text != "string") {
+		return text;
+	}
+	if (!Calendar._decode_el) {
+		Calendar._decode_el = document.createElement("div");
+	}
+	Calendar._decode_el.innerHTML = text;
+	return Calendar._decode_el.textContent || Calendar._decode_el.innerText || text;
+};
+
 // END: UTILITY FUNCTIONS
 
 // BEGIN: CALENDAR STATIC FUNCTIONS
@@ -641,13 +652,7 @@ Calendar.prototype.create = function (_par) {
 		Calendar._add_evs(cell);
 		cell.calendar = cal;
 		cell.navtype = navtype;
-		if (text.substr(0, 1) != "&") {
-			cell.appendChild(document.createTextNode(text));
-		}
-		else {
-			// FIXME: dirty hack for entities
-			cell.innerHTML = text;
-		}
+		cell.appendChild(document.createTextNode(Calendar.htmlDecode(text)));
 		return cell;
 	};
 


### PR DESCRIPTION
🎯 **What**
Replaced a "dirty hack" for handling HTML entities in the calendar navigation buttons. The old code checked if a string started with `&` and used `innerHTML` if so. I've implemented a `Calendar.htmlDecode` utility that properly decodes HTML entities using a temporary DOM element.

💡 **Why**
This improves code health and security. Using `innerHTML` for entity rendering is fragile and can be an XSS vector if labels are dynamically generated. By decoding the entities first and using `createTextNode`, we ensure safe and correct rendering of navigation characters like `«` (`&laquo;`).

✅ **Verification**
- Verified the implementation manually via `read_file`.
- Ran existing project tests (`tests/cli_runner.php`).
- Performed visual verification using a Playwright script on `modules/projectdesigner/jscalendar/index.html` to ensure the calendar renders and functions correctly.

✨ **Result**
A cleaner, safer way to handle special characters in the calendar's navigation UI, synchronized across all redundant copies of the library in the codebase.

---
*PR created automatically by Jules for task [5578863881666309914](https://jules.google.com/task/5578863881666309914) started by @davmont*