### PR TITLE
🧪 [testing improvement] Enhance test coverage for CAppUI getMsg

### DIFF
--- a/tests/UITest.php
+++ b/tests/UITest.php
@@ -184,9 +184,22 @@ class UITest extends TestCase {
         $expected = '<table cellspacing="0" cellpadding="1" border="0"><tr><td><img src="path/to/stock_cancel-16.png" /></td><td class="error">Error</td></tr></table>';
         $this->assertEquals($expected, $ui->getMsg(false));
 
-        // Test resetting (true by default)
-        $ui->setMsg('Test Reset');
+        // Test unknown type (falls to default)
+        $ui->setMsg('Unknown', 999);
+        $expected = '<table cellspacing="0" cellpadding="1" border="0"><tr><td></td><td class="message">Unknown</td></tr></table>';
+        $this->assertEquals($expected, $ui->getMsg(false));
+
+        // Test resetting explicitly
+        $ui->setMsg('Test Reset Explicit');
         $msg = $ui->getMsg(true);
+        $this->assert($msg != '', "Message should not be empty");
+        $this->assertEquals('', $ui->msg);
+        $this->assertEquals(0, $ui->msgNo);
+        $this->assertEquals('', $ui->getMsg());
+
+        // Test resetting (true by default)
+        $ui->setMsg('Test Default Reset');
+        $msg = $ui->getMsg();
         $this->assert($msg != '', "Message should not be empty");
         $this->assertEquals('', $ui->msg);
         $this->assertEquals(0, $ui->msgNo);


### PR DESCRIPTION
🎯 **What:** The `getMsg` method in `classes/ui.class.php` lacked complete test coverage, particularly missing tests for the default behavior (resetting the message state) and handling unknown message types via the switch statement fallback.
📊 **Coverage:** The test suite now explicitly validates:
- The `getMsg(false)` output when the `msgNo` is unknown (fallback to `message` class).
- The explicit resetting of the state via `getMsg(true)`.
- The implicit resetting of the state via `getMsg()` (testing the default parameter value).
✨ **Result:** Improved test coverage and reliability for UI message retrieval and state management.

---
*PR created automatically by Jules for task [5615734050747887225](https://jules.google.com/task/5615734050747887225) started by @davmont*