### PR TITLE
🧪 Add tests for DBQuery::setLimit and addLimit

### DIFF
--- a/tests/DBQueryTest.php
+++ b/tests/DBQueryTest.php
@@ -28,5 +28,33 @@ class DBQueryTest extends TestCase {
         // It removes quote, semicolon and double dash
         $this->assertEquals('admin DROP TABLE users ', $q->sanitise('admin"; DROP TABLE users; --'));
     }
+
+    function testLimit() {
+        $q = new DBQuery('test_');
+
+        // Initial state
+        $this->assertEquals(null, $q->limit);
+        $this->assertEquals(-1, $q->offset);
+
+        // setLimit with only limit
+        $q->setLimit(10);
+        $this->assertEquals(10, $q->limit);
+        $this->assertEquals(-1, $q->offset);
+
+        // setLimit with limit and offset
+        $q->setLimit(20, 5);
+        $this->assertEquals(20, $q->limit);
+        $this->assertEquals(5, $q->offset);
+
+        // addLimit with limit and offset
+        $q->addLimit(30, 15);
+        $this->assertEquals(30, $q->limit);
+        $this->assertEquals(15, $q->offset);
+
+        // addLimit with only limit (default start is 0)
+        $q->addLimit(50);
+        $this->assertEquals(50, $q->limit);
+        $this->assertEquals(0, $q->offset);
+    }
 }
 ?>


### PR DESCRIPTION
🎯 **What:** The `setLimit` method in `DBQuery` was untested.
📊 **Coverage:** Added `testLimit` to `DBQueryTest` which covers `setLimit` (default offset and explicit offset) and `addLimit` (explicit offset and default 0 offset).
✨ **Result:** Improved test coverage for `DBQuery` class, ensuring query limits are correctly handled.

---
*PR created automatically by Jules for task [480848127697525763](https://jules.google.com/task/480848127697525763) started by @davmont*