### PR TITLE
🧹 [code health improvement] Remove commented out code in modules/bugspray/view.php

### DIFF
--- a/modules/bugspray/view.php
+++ b/modules/bugspray/view.php
@@ -217,16 +217,9 @@ function toggle_comment(id){
 <?php 
 
 $tabBox = new CTabBox( "?m=helpdesk&a=view&item_id=$item_id", "", $tab );
-//if ( $obj->task_dynamic == 0 ) {
-	// tabbed information boxes
+// tabbed information boxes
 $tabBox->add( "{$AppUI->cfg['root_dir']}/modules/helpdesk/vw_logs", 'Task Logs' );
-	// fixed bug that dP automatically jumped to access denied if user does not
-	// have read-write permissions on task_id and this tab is opened by default (session_vars)
-	// only if user has r-w perms on this task, new or edit log is beign showed
-//	if (!getDenyEdit( $m, $task_id )) {
 $tabBox->add( "{$AppUI->cfg['root_dir']}/modules/helpdesk/vw_log_update", 'New Log' );
-//	}
-//}
 $tabBox->show();
 } 
 ?>


### PR DESCRIPTION
🎯 **What:** Removed commented-out logic related to task access control from `modules/bugspray/view.php`.
💡 **Why:** Dead, commented-out code clutters the codebase, confuses developers about the actual behavior, and creates unnecessary noise. Removing it improves readability and maintainability.
✅ **Verification:** Ran `php -l` to ensure there are no syntax errors and verified the test suite still passes without new errors. The removal was purely cosmetic as it only targeted commented-out code.
✨ **Result:** A cleaner and more readable `view.php` file in the bugspray module.

---
*PR created automatically by Jules for task [15872756272291296173](https://jules.google.com/task/15872756272291296173) started by @davmont*