### PR TITLE
🔒 Fix Reflected XSS vulnerability in communication addedit

### DIFF
--- a/modules/communication/addedit.php
+++ b/modules/communication/addedit.php
@@ -126,10 +126,10 @@ $titleBlock->show();
                         </td>
                     </tr>
                     <tr><td align="left" nowrap="nowrap"><?php echo $AppUI->_("LBL_TITLE"); ?>:</td>
-                        <td><input type="text" align="left" name="communication_title" cols="50" rows="1" value="<?php echo (isset($_GET['title']) ? htmlspecialchars($_GET['title']) : @$obj->communication_title); ?>"></input></td>
+                        <td><input type="text" align="left" name="communication_title" cols="50" rows="1" value="<?php echo (isset($_GET['title']) ? htmlspecialchars((string)$_GET['title'], ENT_QUOTES) : htmlspecialchars((string)@$obj->communication_title, ENT_QUOTES)); ?>"></input></td>
                     </tr>
                     <tr><td align="left" nowrap="nowrap"><?php echo $AppUI->_("LBL_COMMUNICATION"); ?>:</td>
-                        <td align="left"><textarea name="communication_information" cols="100" rows="3" class="textarea"><?php echo (isset($_GET['communication']) ? htmlspecialchars($_GET['communication']) : @$obj->communication_information); ?></textarea></td>
+                        <td align="left"><textarea name="communication_information" cols="100" rows="3" class="textarea"><?php echo (isset($_GET['communication']) ? htmlspecialchars((string)$_GET['communication'], ENT_QUOTES) : htmlspecialchars((string)@$obj->communication_information, ENT_QUOTES)); ?></textarea></td>
                     </tr>  
                     <?php
                     if ($communication_id!=0) {
@@ -222,11 +222,11 @@ $titleBlock->show();
                   }
                   ?></select>
                     <span style="margin-left:15px; <?php echo ($showdate ? '' : 'display:none;'); ?>"><?php echo $AppUI->_("LBL_DATE")?>: </span>
-                    <input type="text" style="<?php echo ($showdate ? '' : 'display:none;'); ?> margin-left: 10px;" value="<?php echo ($communication_id == 0 ? htmlspecialchars($_GET['communication_date']) : @$obj->communication_date);  ?>" name="communication_date">
+                    <input type="text" style="<?php echo ($showdate ? '' : 'display:none;'); ?> margin-left: 10px;" value="<?php echo ($communication_id == 0 ? htmlspecialchars((string)$_GET['communication_date'], ENT_QUOTES) : htmlspecialchars((string)@$obj->communication_date, ENT_QUOTES));  ?>" name="communication_date">
                     </td>
                  </tr>
                  <tr><td align="left" nowrap="nowrap"><?php echo $AppUI->_("LBL_RESTRICTIONS");?>: </td>
-                     <td align="left"><textarea name="communication_restrictions" cols="100" rows="3" class="textarea"><?php echo ($communication_id == 0 ? htmlspecialchars($_GET['restrictions']) : @$obj->communication_restrictions); ?></textarea></td>
+                     <td align="left"><textarea name="communication_restrictions" cols="100" rows="3" class="textarea"><?php echo ($communication_id == 0 ? htmlspecialchars((string)$_GET['restrictions'], ENT_QUOTES) : htmlspecialchars((string)@$obj->communication_restrictions, ENT_QUOTES)); ?></textarea></td>
                  </tr>
                  <td align="left" nowrap="nowrap"><?php echo $AppUI->_("LBL_RESPONSIBLE");?>: </td> 
                      <td><select id="responsible" name="responsible" style="min-width:150px">


### PR DESCRIPTION
🎯 **What:** Fixed Reflected Cross-Site Scripting (XSS) vulnerabilities in `modules/communication/addedit.php` by properly escaping `$_GET` variables printed in HTML attributes and text areas.

⚠️ **Risk:** Unescaped `$_GET` variables could allow attackers to inject malicious HTML or JavaScript code, leading to XSS attacks which could compromise user accounts or sensitive data. 

🛡️ **Solution:** Used `htmlspecialchars` with `ENT_QUOTES` to securely encode output in HTML attributes and fields. Explicitly casted variables to a `(string)` before encoding to prevent deprecation warnings in PHP 8.1+ when the value is null. Applied these fixes to `$obj->communication_title`, `$obj->communication_information`, `$obj->communication_date`, and `$obj->communication_restrictions`.

---
*PR created automatically by Jules for task [2553539513443777665](https://jules.google.com/task/2553539513443777665) started by @davmont*